### PR TITLE
Remove EventHandler interface

### DIFF
--- a/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/EventHandler.kt
+++ b/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/EventHandler.kt
@@ -1,7 +1,0 @@
-package io.skrastrek.aws.lambda.kotlin.core
-
-import kotlinx.serialization.builtins.serializer
-
-interface EventHandler<I : Any> : RequestHandler<I, Unit> {
-    override val serializer get() = Unit.serializer()
-}


### PR DESCRIPTION
Removes `EventHandler<I>`, which was a thin alias for `RequestHandler<I, Unit>`.

## Why

The interface was premised on event-invoked functions having no output. That premise doesn't hold:

- **Event source mappings do return a payload.** With `ReportBatchItemFailures` enabled, SQS/DynamoDB/Kinesis handlers return partial-batch-failure results — that's exactly what `BatchEventResponse` in the `events` module is for.
- **Async invocations return a payload too.** The return value is delivered to an `OnSuccess` destination as `responsePayload`.

So "event-invoked" and "has no output" are orthogonal, and the name asserted a coupling that isn't there.

It also didn't mean "no output" in practice — `Unit.serializer()` is an object serializer, so it wrote `{}` to the response stream rather than suppressing the body.

The interface saved exactly one line (`override val serializer get() = Unit.serializer()`), had no usages in this repo, and no tests or docs referencing it.

## Migration

Handlers that genuinely have nothing to return declare it directly:

```kotlin
object MyHandler : RequestHandler<MyEvent, Unit> {
    override val deserializer get() = MyEvent.serializer()
    override val serializer get() = Unit.serializer()

    override fun handleRequest(input: MyEvent, context: Context) { /* ... */ }
}
```

## Breaking change

`EventHandler` is removed from the public API, so this needs a major version bump. Release is handled separately.

`./gradlew build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)