### PR TITLE
Suspending request handlers, and rename typed handler method to handle

### DIFF
--- a/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/RequestHandler.kt
+++ b/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/RequestHandler.kt
@@ -24,16 +24,17 @@ interface RequestHandler<I : Any, O : Any> : RequestStreamHandler {
     val deserializer: DeserializationStrategy<I>
     val serializer: SerializationStrategy<O>
 
-    fun handleRequest(
+    fun handle(
         input: I,
         context: Context,
     ): O
 
+    /** AWS's entry point. Named by the platform contract, not by us — implement [handle] instead. */
     override fun handleRequest(
         input: InputStream,
         output: OutputStream,
         context: Context,
-    ) = handleRequest(input.jsonDecode(), context).jsonEncodeTo(output)
+    ) = handle(input.jsonDecode(), context).jsonEncodeTo(output)
 
     @OptIn(ExperimentalSerializationApi::class)
     private fun InputStream.jsonDecode(): I = json.decodeFromStream(deserializer, this)
@@ -42,9 +43,9 @@ interface RequestHandler<I : Any, O : Any> : RequestStreamHandler {
     private fun O.jsonEncodeTo(output: OutputStream) = json.encodeToStream(serializer, this, output)
 }
 
-fun <I : Any, O : Any> RequestHandler<I, O>.handleRequest(input: I): O = handleRequest(input, EmptyContext)
+fun <I : Any, O : Any> RequestHandler<I, O>.handle(input: I): O = handle(input, EmptyContext)
 
-fun <I : Any, O : Any> RequestHandler<I, O>.handleRequest(
+fun <I : Any, O : Any> RequestHandler<I, O>.handle(
     input: InputStream,
     output: OutputStream,
 ) = handleRequest(input, output, EmptyContext)

--- a/core/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/core/RequestHandlerTest.kt
+++ b/core/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/core/RequestHandlerTest.kt
@@ -14,7 +14,7 @@ class RequestHandlerTest {
         val input = ByteArrayInputStream(json.encodeToString("hello world").toByteArray())
         val output = ByteArrayOutputStream()
 
-        CapitalizeRequestHandler.handleRequest(input, output)
+        CapitalizeRequestHandler.handle(input, output)
 
         assertEquals(json.encodeToString("HELLO WORLD"), output.toString(Charsets.UTF_8))
     }
@@ -24,7 +24,7 @@ private object CapitalizeRequestHandler : RequestHandler<String, String> {
     override val deserializer get() = String.serializer()
     override val serializer get() = String.serializer()
 
-    override fun handleRequest(
+    override fun handle(
         input: String,
         context: Context,
     ): String = input.uppercase()

--- a/coroutines/build.gradle.kts
+++ b/coroutines/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
-    api(project(":coroutines"))
-    implementation(libs.kotlinx.coroutines.core)
+    api(project(":core"))
+    api(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)
     testImplementation(kotlin("test"))
     testImplementation(libs.kotlinx.coroutines.test)

--- a/coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestHandler.kt
+++ b/coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestHandler.kt
@@ -1,0 +1,56 @@
+package io.skrastrek.aws.lambda.kotlin.coroutines
+
+import com.amazonaws.services.lambda.runtime.Context
+import io.skrastrek.aws.lambda.kotlin.core.EmptyContext
+import io.skrastrek.aws.lambda.kotlin.core.json
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.json.decodeFromStream
+import kotlinx.serialization.json.encodeToStream
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * Suspending counterpart to [io.skrastrek.aws.lambda.kotlin.core.RequestHandler].
+ *
+ * This is a sibling of the blocking hierarchy rather than a subtype of it: inheriting the blocking
+ * `handleRequest(I, Context)` would conflict with the suspending one declared here.
+ *
+ * Decoding and encoding are confined to [IO] so the handler stays correct whichever dispatcher the
+ * caller uses, while [handleRequest] itself runs on the caller's context.
+ */
+interface SuspendingRequestHandler<I : Any, O : Any> : SuspendingRequestStreamHandler {
+    val deserializer: DeserializationStrategy<I>
+    val serializer: SerializationStrategy<O>
+
+    suspend fun handleRequest(
+        input: I,
+        context: Context,
+    ): O
+
+    override suspend fun handle(
+        input: InputStream,
+        output: OutputStream,
+        context: Context,
+    ) {
+        val decoded = withContext(IO) { input.jsonDecode() }
+        val result = handleRequest(decoded, context)
+        withContext(IO) { result.jsonEncodeTo(output) }
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    private fun InputStream.jsonDecode(): I = json.decodeFromStream(deserializer, this)
+
+    @OptIn(ExperimentalSerializationApi::class)
+    private fun O.jsonEncodeTo(output: OutputStream) = json.encodeToStream(serializer, this, output)
+}
+
+suspend fun <I : Any, O : Any> SuspendingRequestHandler<I, O>.handleRequest(input: I): O = handleRequest(input, EmptyContext)
+
+suspend fun <I : Any, O : Any> SuspendingRequestHandler<I, O>.handle(
+    input: InputStream,
+    output: OutputStream,
+) = handle(input, output, EmptyContext)

--- a/coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestHandler.kt
+++ b/coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestHandler.kt
@@ -17,16 +17,16 @@ import java.io.OutputStream
  * Suspending counterpart to [io.skrastrek.aws.lambda.kotlin.core.RequestHandler].
  *
  * This is a sibling of the blocking hierarchy rather than a subtype of it: inheriting the blocking
- * `handleRequest(I, Context)` would conflict with the suspending one declared here.
+ * `handle(I, Context)` would conflict with the suspending one declared here.
  *
  * Decoding and encoding are confined to [IO] so the handler stays correct whichever dispatcher the
- * caller uses, while [handleRequest] itself runs on the caller's context.
+ * caller uses, while [handle] itself runs on the caller's context.
  */
 interface SuspendingRequestHandler<I : Any, O : Any> : SuspendingRequestStreamHandler {
     val deserializer: DeserializationStrategy<I>
     val serializer: SerializationStrategy<O>
 
-    suspend fun handleRequest(
+    suspend fun handle(
         input: I,
         context: Context,
     ): O
@@ -37,7 +37,7 @@ interface SuspendingRequestHandler<I : Any, O : Any> : SuspendingRequestStreamHa
         context: Context,
     ) {
         val decoded = withContext(IO) { input.jsonDecode() }
-        val result = handleRequest(decoded, context)
+        val result = handle(decoded, context)
         withContext(IO) { result.jsonEncodeTo(output) }
     }
 
@@ -48,7 +48,7 @@ interface SuspendingRequestHandler<I : Any, O : Any> : SuspendingRequestStreamHa
     private fun O.jsonEncodeTo(output: OutputStream) = json.encodeToStream(serializer, this, output)
 }
 
-suspend fun <I : Any, O : Any> SuspendingRequestHandler<I, O>.handleRequest(input: I): O = handleRequest(input, EmptyContext)
+suspend fun <I : Any, O : Any> SuspendingRequestHandler<I, O>.handle(input: I): O = handle(input, EmptyContext)
 
 suspend fun <I : Any, O : Any> SuspendingRequestHandler<I, O>.handle(
     input: InputStream,

--- a/coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestStreamHandler.kt
+++ b/coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestStreamHandler.kt
@@ -11,9 +11,10 @@ import java.io.OutputStream
 /**
  * Suspending counterpart to [RequestStreamHandler].
  *
- * The suspending entry point is named [handle] rather than `handleRequest` because Kotlin does not
- * treat the `suspend` modifier as part of a function signature, so a suspending overload with the
- * same parameters as the inherited blocking one would be a conflicting overload.
+ * `handle` is the name to implement across this library; `handleRequest` belongs to AWS. Here the
+ * distinction is also forced: a `suspend fun handleRequest` with these parameters is read as an
+ * attempt to override the inherited blocking one, which the compiler rejects with "suspend function
+ * cannot override non-suspend function".
  *
  * Extending [RequestStreamHandler] keeps implementations deployable on the AWS managed Java
  * runtime, whose bootstrap resolves handlers by that exact type. On that path [handleRequest]

--- a/coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestStreamHandler.kt
+++ b/coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestStreamHandler.kt
@@ -1,0 +1,62 @@
+package io.skrastrek.aws.lambda.kotlin.coroutines
+
+import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * Suspending counterpart to [RequestStreamHandler].
+ *
+ * The suspending entry point is named [handle] rather than `handleRequest` because Kotlin does not
+ * treat the `suspend` modifier as part of a function signature, so a suspending overload with the
+ * same parameters as the inherited blocking one would be a conflicting overload.
+ *
+ * Extending [RequestStreamHandler] keeps implementations deployable on the AWS managed Java
+ * runtime, whose bootstrap resolves handlers by that exact type. On that path [handleRequest]
+ * bridges into [handle] with [runBlocking], which is safe because Lambda serves one invocation per
+ * thread. On the custom runtime, `LambdaNativeRuntime` calls [handle] directly and the bridge is
+ * never used.
+ */
+interface SuspendingRequestStreamHandler : RequestStreamHandler {
+    suspend fun handle(
+        input: InputStream,
+        output: OutputStream,
+        context: Context,
+    )
+
+    override fun handleRequest(
+        input: InputStream,
+        output: OutputStream,
+        context: Context,
+    ) = runBlocking { handle(input, output, context) }
+}
+
+/**
+ * Views this handler as a [SuspendingRequestStreamHandler].
+ *
+ * Returns the receiver unchanged when it already suspends, so callers never pay for a
+ * [runBlocking] bridge that would pin a thread for the duration of an invocation. A blocking
+ * handler is wrapped so its work runs on [IO].
+ */
+fun RequestStreamHandler.asSuspending(): SuspendingRequestStreamHandler =
+    this as? SuspendingRequestStreamHandler ?: BlockingRequestStreamHandler(this)
+
+private class BlockingRequestStreamHandler(
+    private val delegate: RequestStreamHandler,
+) : SuspendingRequestStreamHandler {
+    override suspend fun handle(
+        input: InputStream,
+        output: OutputStream,
+        context: Context,
+    ) = withContext(IO) { delegate.handleRequest(input, output, context) }
+
+    override fun handleRequest(
+        input: InputStream,
+        output: OutputStream,
+        context: Context,
+    ) = delegate.handleRequest(input, output, context)
+}

--- a/coroutines/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestHandlerTest.kt
+++ b/coroutines/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestHandlerTest.kt
@@ -62,7 +62,7 @@ private object CapitalizeRequestHandler : SuspendingRequestHandler<String, Strin
     override val deserializer get() = String.serializer()
     override val serializer get() = String.serializer()
 
-    override suspend fun handleRequest(
+    override suspend fun handle(
         input: String,
         context: Context,
     ): String {

--- a/coroutines/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestHandlerTest.kt
+++ b/coroutines/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestHandlerTest.kt
@@ -1,0 +1,72 @@
+package io.skrastrek.aws.lambda.kotlin.coroutines
+
+import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler
+import io.skrastrek.aws.lambda.kotlin.core.EmptyContext
+import io.skrastrek.aws.lambda.kotlin.core.json
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.encodeToString
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+
+class SuspendingRequestHandlerTest {
+    @Test
+    fun `suspending handle decodes, invokes and encodes`() =
+        runTest {
+            val input = ByteArrayInputStream(json.encodeToString("hello world").toByteArray())
+            val output = ByteArrayOutputStream()
+
+            CapitalizeRequestHandler.handle(input, output)
+
+            assertEquals(json.encodeToString("HELLO WORLD"), output.toString(Charsets.UTF_8))
+        }
+
+    @Test
+    fun `blocking bridge runs the suspending handler`() {
+        val input = ByteArrayInputStream(json.encodeToString("hello world").toByteArray())
+        val output = ByteArrayOutputStream()
+
+        // The AWS-facing entry point: this is what the managed Java runtime invokes.
+        CapitalizeRequestHandler.handleRequest(input, output, EmptyContext)
+
+        assertEquals(json.encodeToString("HELLO WORLD"), output.toString(Charsets.UTF_8))
+    }
+
+    @Test
+    fun `asSuspending returns a suspending handler unchanged`() {
+        assertSame(CapitalizeRequestHandler, CapitalizeRequestHandler.asSuspending())
+    }
+
+    @Test
+    fun `asSuspending wraps a blocking handler`() =
+        runTest {
+            val blocking = RequestStreamHandler { input, output, _ -> output.write(input.readBytes()) }
+            val suspending = blocking.asSuspending()
+            val output = ByteArrayOutputStream()
+
+            assertNotSame<Any>(blocking, suspending)
+
+            suspending.handle(ByteArrayInputStream("payload".toByteArray()), output, EmptyContext)
+
+            assertEquals("payload", output.toString(Charsets.UTF_8))
+        }
+}
+
+private object CapitalizeRequestHandler : SuspendingRequestHandler<String, String> {
+    override val deserializer get() = String.serializer()
+    override val serializer get() = String.serializer()
+
+    override suspend fun handleRequest(
+        input: String,
+        context: Context,
+    ): String {
+        delay(1)
+        return input.uppercase()
+    }
+}

--- a/runtime/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/runtime/LambdaNativeRuntime.kt
+++ b/runtime/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/runtime/LambdaNativeRuntime.kt
@@ -5,6 +5,8 @@ import com.amazonaws.services.lambda.runtime.CognitoIdentity
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.LambdaLogger
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler
+import io.skrastrek.aws.lambda.kotlin.coroutines.SuspendingRequestStreamHandler
+import io.skrastrek.aws.lambda.kotlin.coroutines.asSuspending
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -29,6 +31,12 @@ abstract class LambdaNativeRuntime(
     protected val runtimeApiBaseUrl: String,
 ) {
     protected val http: HttpClient = HttpClient.newHttpClient()
+
+    /**
+     * The handler as a suspending one. Already-suspending handlers are used as-is, so an invocation
+     * that awaits IO releases its thread instead of parking it inside [kotlinx.coroutines.runBlocking].
+     */
+    protected val suspendingHandler: SuspendingRequestStreamHandler = handler.asSuspending()
 
     fun start() =
         runBlocking {
@@ -83,9 +91,9 @@ abstract class LambdaNativeRuntime(
             eventStream: InputStream,
             context: Context,
         ) {
+            val output = ByteArrayOutputStream()
+            suspendingHandler.handle(eventStream, output, context)
             withContext(IO) {
-                val output = ByteArrayOutputStream()
-                handler.handleRequest(eventStream, output, context)
                 http.send(
                     HttpRequest.newBuilder()
                         .uri(URI.create("${this@BufferedResponse.runtimeApiBaseUrl}/invocation/$requestId/response"))
@@ -110,8 +118,10 @@ abstract class LambdaNativeRuntime(
             coroutineScope {
                 val pipedOutput = PipedOutputStream()
                 val pipedInput = PipedInputStream(pipedOutput, 65536)
+                // Stays on IO: PipedOutputStream.write blocks once the buffer fills, regardless of
+                // whether the handler itself suspends.
                 launch(IO) {
-                    pipedOutput.use { handler.handleRequest(eventStream, it, context) }
+                    pipedOutput.use { suspendingHandler.handle(eventStream, it, context) }
                 }
                 withContext(IO) {
                     http.send(

--- a/runtime/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/runtime/LambdaNativeRuntimeTest.kt
+++ b/runtime/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/runtime/LambdaNativeRuntimeTest.kt
@@ -1,13 +1,18 @@
 package io.skrastrek.aws.lambda.kotlin.runtime
 
+import com.amazonaws.services.lambda.runtime.Context
 import com.sun.net.httpserver.HttpServer
+import io.skrastrek.aws.lambda.kotlin.coroutines.SuspendingRequestStreamHandler
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import java.io.InputStream
+import java.io.OutputStream
 import java.net.InetSocketAddress
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -178,6 +183,76 @@ class LambdaNativeRuntimeTest {
 
             val body = capturedErrorBody.await()
             assertTrue(""""errorMessage":"stream error"""" in body)
+            assertTrue(""""errorType":"java.lang.RuntimeException"""" in body)
+            assertEquals("Unhandled", capturedErrorType.await())
+        }
+
+    @Test
+    fun `BufferedResponse invokes a suspending handler and posts its output`() =
+        runTest {
+            val requestId = "req-suspending-01"
+            val eventBody = """{"action":"suspend"}"""
+            val capturedBody = CompletableDeferred<String>()
+
+            registerNextInvocation(requestId, eventBody)
+            server.createContext("/2018-06-01/runtime/invocation/$requestId/response") { exchange ->
+                capturedBody.complete(exchange.requestBody.readBytes().decodeToString())
+                exchange.sendResponseHeaders(202, -1)
+                exchange.close()
+            }
+
+            startRuntime(
+                LambdaNativeRuntime.BufferedResponse(
+                    object : SuspendingRequestStreamHandler {
+                        override suspend fun handle(
+                            input: InputStream,
+                            output: OutputStream,
+                            context: Context,
+                        ) {
+                            delay(10)
+                            output.write(input.readBytes())
+                        }
+                    },
+                    base(),
+                ),
+            )
+
+            assertEquals(eventBody, capturedBody.await())
+        }
+
+    @Test
+    fun `BufferedResponse posts to error endpoint when a suspending handler throws`() =
+        runTest {
+            val requestId = "req-suspending-02"
+            val capturedErrorBody = CompletableDeferred<String>()
+            val capturedErrorType = CompletableDeferred<String>()
+
+            registerNextInvocation(requestId, "{}")
+            server.createContext("/2018-06-01/runtime/invocation/$requestId/error") { exchange ->
+                capturedErrorBody.complete(exchange.requestBody.readBytes().decodeToString())
+                capturedErrorType.complete(exchange.requestHeaders.getFirst("Lambda-Runtime-Function-Error-Type"))
+                exchange.sendResponseHeaders(202, -1)
+                exchange.close()
+            }
+
+            startRuntime(
+                LambdaNativeRuntime.BufferedResponse(
+                    object : SuspendingRequestStreamHandler {
+                        override suspend fun handle(
+                            input: InputStream,
+                            output: OutputStream,
+                            context: Context,
+                        ) {
+                            delay(10)
+                            throw RuntimeException("suspending handler error")
+                        }
+                    },
+                    base(),
+                ),
+            )
+
+            val body = capturedErrorBody.await()
+            assertTrue(""""errorMessage":"suspending handler error"""" in body)
             assertTrue(""""errorType":"java.lang.RuntimeException"""" in body)
             assertEquals("Unhandled", capturedErrorType.await())
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "aws-lambda-kotlin"
 
 include(
     "core",
+    "coroutines",
     "events",
     "runtime"
 )


### PR DESCRIPTION
Adds a coroutine-native handler hierarchy alongside the existing blocking one, so handlers can `suspend` without a thread-blocking bridge on the custom runtime — while staying deployable on the AWS managed Java runtime. Also unifies the method name across both hierarchies.

## ⚠️ Breaking change

`RequestHandler<I, O>.handleRequest(input: I, context: Context)` is now **`handle(input: I, context: Context)`**, along with the `EmptyContext` convenience extensions.

```kotlin
object MyHandler : RequestHandler<MyEvent, MyResult> {
    override val deserializer get() = MyEvent.serializer()
    override val serializer get() = MyResult.serializer()

-   override fun handleRequest(input: MyEvent, context: Context): MyResult = ...
+   override fun handle(input: MyEvent, context: Context): MyResult = ...
}
```

The rule this establishes: **`handle` is the method you implement; `handleRequest` is AWS's inherited entry point and nothing else.** The `RequestStreamHandler` overrides keep their name, because that one is the managed runtime's contract rather than ours.

Needs a major bump, which it can share with #77.

## New `:coroutines` module

`kotlinx-coroutines-core` is 1.5 MB. Putting these types in `:core` would make it an `api` dependency of every `core`/`events` consumer, who would pay for it at cold start whether or not they use coroutines. So they live in a new `aws-lambda-kotlin-coroutines` artifact:

```
core (no coroutines)
├── events
└── coroutines   ← new
      └── runtime
```

## `SuspendingRequestStreamHandler`

```kotlin
interface SuspendingRequestStreamHandler : RequestStreamHandler {
    suspend fun handle(input: InputStream, output: OutputStream, context: Context)

    override fun handleRequest(input: InputStream, output: OutputStream, context: Context) =
        runBlocking { handle(input, output, context) }
}
```

Extending AWS's `RequestStreamHandler` is what keeps implementations deployable on the managed `java25` runtime, whose bootstrap resolves handlers by that exact type. On that path `handleRequest` bridges via `runBlocking`, which is safe because Lambda serves one invocation per thread.

Here the `handle` name is not just convention but forced — a `suspend fun handleRequest` with these parameters is read as an attempt to override the inherited blocking one:

> Suspend function 'handleRequest' cannot override non-suspend function 'fun handleRequest(p0: InputStream!, p1: OutputStream!, p2: Context!): Unit' defined in 'com.amazonaws.services.lambda.runtime.RequestStreamHandler'.

## `SuspendingRequestHandler<I, O>`

The typed layer, mirroring `RequestHandler<I, O>`. It is a **sibling** of the blocking interface rather than a subtype — inheriting the blocking `handle(I, Context)` would collide with the suspending one declared here.

Stream decode/encode is confined to `Dispatchers.IO` so the handler is correct whichever dispatcher the caller uses, while the user's `handle` body runs on the caller's context.

Per #77, there is no `SuspendingEventHandler` counterpart.

## Runtime wiring — the part that makes this worth having

`LambdaNativeRuntime` previously called the blocking `handleRequest` inside `withContext(IO)`. Hand it a suspending handler and you would get `runBlocking` *inside* a coroutine: a handler awaiting an HTTP call would pin an IO thread for the whole invocation, which is exactly what we are trying to avoid.

It now dispatches through `asSuspending()`, which returns an already-suspending handler unchanged and wraps a blocking one to run on `IO`. The constructor still takes `RequestStreamHandler`, so this part is source- and binary-compatible for existing callers, and `suspendingHandler` is an additive `protected` member.

`StreamResponse` deliberately keeps its `launch(IO)`: `PipedOutputStream.write` blocks once the 64 KB buffer fills regardless of whether the handler suspends.

## Tests

16 tests pass across all four modules. New coverage:

- suspending `handle` decodes → invokes → encodes
- the blocking `runBlocking` bridge (the managed-runtime entry point) drives a suspending handler
- `asSuspending()` returns a suspending handler unchanged / wraps a blocking one — this is the assertion that guards the no-`runBlocking`-in-the-runtime property
- native runtime invokes a suspending handler and posts its output
- a suspending handler that throws mid-suspension reaches the error endpoint

`./gradlew build` passes (ktlint included).

## Not included

Two optional follow-ups from the design, left out to keep this reviewable: a `suspend fun run()` entry point on `LambdaNativeRuntime` for callers already inside a coroutine, and switching `http.send` to `sendAsync(...).await()` for a fully non-blocking runtime loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)