### PR TITLE
Suspending handler interfaces for events, shared serializer bindings, overridable JSON config

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    alias(libs.plugins.kotlin.serialization)
+}
+
 dependencies {
     api(libs.aws.lambda.java.core)
     implementation(libs.kotlinx.serialization.json)

--- a/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/HandlerSerializers.kt
+++ b/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/HandlerSerializers.kt
@@ -1,0 +1,30 @@
+package io.skrastrek.aws.lambda.kotlin.core
+
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.SerializationStrategy
+
+/**
+ * The serializer pair a typed handler needs, independent of whether that handler blocks or suspends.
+ *
+ * Both `RequestHandler` and `SuspendingRequestHandler` extend this, which lets an event type state
+ * its serializers once and mix them into either style:
+ *
+ * ```
+ * interface DynamoDbEventSerializers : HandlerSerializers<DynamoDbEvent, BatchEventResponse> {
+ *     override val deserializer get() = DynamoDbEvent.serializer()
+ *     override val serializer get() = BatchEventResponse.serializer()
+ * }
+ *
+ * interface DynamoDbEventRequestHandler :
+ *     RequestHandler<DynamoDbEvent, BatchEventResponse>, DynamoDbEventSerializers
+ * ```
+ *
+ * The shared supertype is what makes that compile. An unrelated interface declaring `deserializer`
+ * and `serializer` would not: Kotlin reports "must override because it inherits multiple interface
+ * methods for it" when the members come from two independent declarations. Routing both styles
+ * through this one leaves exactly a single implementation to resolve to.
+ */
+interface HandlerSerializers<I : Any, O : Any> {
+    val deserializer: DeserializationStrategy<I>
+    val serializer: SerializationStrategy<O>
+}

--- a/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/HandlerSerializers.kt
+++ b/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/HandlerSerializers.kt
@@ -1,10 +1,22 @@
 package io.skrastrek.aws.lambda.kotlin.core
 
 import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.json.Json
+
+/** The configuration every handler uses unless it overrides [HandlerSerializers.json]. */
+@OptIn(ExperimentalSerializationApi::class)
+val defaultJson =
+    Json {
+        encodeDefaults = true
+        explicitNulls = false
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+    }
 
 /**
- * The serializer pair a typed handler needs, independent of whether that handler blocks or suspends.
+ * The serialization a typed handler needs, independent of whether that handler blocks or suspends.
  *
  * Both `RequestHandler` and `SuspendingRequestHandler` extend this, which lets an event type state
  * its serializers once and mix them into either style:
@@ -27,4 +39,28 @@ import kotlinx.serialization.SerializationStrategy
 interface HandlerSerializers<I : Any, O : Any> {
     val deserializer: DeserializationStrategy<I>
     val serializer: SerializationStrategy<O>
+
+    /**
+     * The [Json] used to decode the event and encode the result. Defaults to [defaultJson].
+     *
+     * Override to supply a [kotlinx.serialization.modules.SerializersModule] — registering
+     * contextual serializers explicitly is what keeps serializer lookup off the reflective path,
+     * which a GraalVM native image cannot follow without extra configuration:
+     *
+     * ```
+     * override val json = Json(defaultJson) {
+     *     serializersModule = SerializersModule {
+     *         contextual(ApiGatewayProxyV1Event::class, ApiGatewayProxyV1Event.serializer())
+     *     }
+     * }
+     * ```
+     *
+     * `Json(defaultJson) { … }` copies the base configuration, but assigning `serializersModule`
+     * *replaces* it rather than adding to it. To keep an existing module, combine them:
+     * `serializersModule = defaultJson.serializersModule + SerializersModule { … }`.
+     *
+     * Because this lives on [HandlerSerializers], an event's `…Serializers` interface can set it
+     * once and both the blocking and suspending handlers for that event pick it up.
+     */
+    val json: Json get() = defaultJson
 }

--- a/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/RequestHandler.kt
+++ b/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/RequestHandler.kt
@@ -2,9 +2,7 @@ package io.skrastrek.aws.lambda.kotlin.core
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler
-import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
@@ -20,10 +18,9 @@ val json =
         coerceInputValues = true
     }
 
-interface RequestHandler<I : Any, O : Any> : RequestStreamHandler {
-    val deserializer: DeserializationStrategy<I>
-    val serializer: SerializationStrategy<O>
-
+interface RequestHandler<I : Any, O : Any> :
+    RequestStreamHandler,
+    HandlerSerializers<I, O> {
     fun handle(
         input: I,
         context: Context,

--- a/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/RequestHandler.kt
+++ b/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/RequestHandler.kt
@@ -3,20 +3,10 @@ package io.skrastrek.aws.lambda.kotlin.core
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
 import java.io.InputStream
 import java.io.OutputStream
-
-@OptIn(ExperimentalSerializationApi::class)
-val json =
-    Json {
-        encodeDefaults = true
-        explicitNulls = false
-        ignoreUnknownKeys = true
-        coerceInputValues = true
-    }
 
 interface RequestHandler<I : Any, O : Any> :
     RequestStreamHandler,

--- a/core/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/core/HandlerJsonTest.kt
+++ b/core/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/core/HandlerJsonTest.kt
@@ -1,0 +1,93 @@
+package io.skrastrek.aws.lambda.kotlin.core
+
+import com.amazonaws.services.lambda.runtime.Context
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * A handler can replace the [Json] used for its event and result. Registering serializers
+ * explicitly through a module is what keeps lookup off the reflective path that a GraalVM native
+ * image cannot follow.
+ */
+class HandlerJsonTest {
+    private val payload = """{"payload":"hello"}"""
+
+    @Test
+    fun `overridden json supplies the serializers module`() {
+        val output = ByteArrayOutputStream()
+
+        ContextualHandler.handle(ByteArrayInputStream(payload.toByteArray()), output)
+
+        assertEquals("""{"payload":"HELLO"}""", output.toString(Charsets.UTF_8))
+    }
+
+    @Test
+    fun `the default json has no such serializer, so the override is load-bearing`() {
+        assertFailsWith<SerializationException> {
+            DefaultJsonHandler.handle(ByteArrayInputStream(payload.toByteArray()), ByteArrayOutputStream())
+        }
+    }
+}
+
+@Serializable
+private data class Envelope(
+    @Contextual val payload: Payload,
+)
+
+/** Deliberately not `@Serializable` — only reachable through a contextual registration. */
+private data class Payload(
+    val value: String,
+)
+
+private object PayloadSerializer : KSerializer<Payload> {
+    override val descriptor = PrimitiveSerialDescriptor("Payload", PrimitiveKind.STRING)
+
+    override fun serialize(
+        encoder: Encoder,
+        value: Payload,
+    ) = encoder.encodeString(value.value)
+
+    override fun deserialize(decoder: Decoder) = Payload(decoder.decodeString())
+}
+
+private object ContextualHandler : RequestHandler<Envelope, Envelope> {
+    override val deserializer get() = Envelope.serializer()
+    override val serializer get() = Envelope.serializer()
+
+    override val json =
+        Json(defaultJson) {
+            serializersModule =
+                SerializersModule {
+                    contextual(Payload::class, PayloadSerializer)
+                }
+        }
+
+    override fun handle(
+        input: Envelope,
+        context: Context,
+    ) = Envelope(Payload(input.payload.value.uppercase()))
+}
+
+private object DefaultJsonHandler : RequestHandler<Envelope, Envelope> {
+    override val deserializer get() = Envelope.serializer()
+    override val serializer get() = Envelope.serializer()
+
+    override fun handle(
+        input: Envelope,
+        context: Context,
+    ) = input
+}

--- a/core/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/core/RequestHandlerTest.kt
+++ b/core/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/core/RequestHandlerTest.kt
@@ -11,12 +11,12 @@ import kotlin.test.assertEquals
 class RequestHandlerTest {
     @Test
     fun handle_request() {
-        val input = ByteArrayInputStream(json.encodeToString("hello world").toByteArray())
+        val input = ByteArrayInputStream(defaultJson.encodeToString("hello world").toByteArray())
         val output = ByteArrayOutputStream()
 
         CapitalizeRequestHandler.handle(input, output)
 
-        assertEquals(json.encodeToString("HELLO WORLD"), output.toString(Charsets.UTF_8))
+        assertEquals(defaultJson.encodeToString("HELLO WORLD"), output.toString(Charsets.UTF_8))
     }
 }
 

--- a/coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestHandler.kt
+++ b/coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestHandler.kt
@@ -3,7 +3,6 @@ package io.skrastrek.aws.lambda.kotlin.coroutines
 import com.amazonaws.services.lambda.runtime.Context
 import io.skrastrek.aws.lambda.kotlin.core.EmptyContext
 import io.skrastrek.aws.lambda.kotlin.core.HandlerSerializers
-import io.skrastrek.aws.lambda.kotlin.core.json
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.ExperimentalSerializationApi

--- a/coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestHandler.kt
+++ b/coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestHandler.kt
@@ -2,12 +2,11 @@ package io.skrastrek.aws.lambda.kotlin.coroutines
 
 import com.amazonaws.services.lambda.runtime.Context
 import io.skrastrek.aws.lambda.kotlin.core.EmptyContext
+import io.skrastrek.aws.lambda.kotlin.core.HandlerSerializers
 import io.skrastrek.aws.lambda.kotlin.core.json
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
 import java.io.InputStream
@@ -22,10 +21,9 @@ import java.io.OutputStream
  * Decoding and encoding are confined to [IO] so the handler stays correct whichever dispatcher the
  * caller uses, while [handle] itself runs on the caller's context.
  */
-interface SuspendingRequestHandler<I : Any, O : Any> : SuspendingRequestStreamHandler {
-    val deserializer: DeserializationStrategy<I>
-    val serializer: SerializationStrategy<O>
-
+interface SuspendingRequestHandler<I : Any, O : Any> :
+    SuspendingRequestStreamHandler,
+    HandlerSerializers<I, O> {
     suspend fun handle(
         input: I,
         context: Context,

--- a/coroutines/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestHandlerTest.kt
+++ b/coroutines/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestHandlerTest.kt
@@ -3,11 +3,13 @@ package io.skrastrek.aws.lambda.kotlin.coroutines
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler
 import io.skrastrek.aws.lambda.kotlin.core.EmptyContext
-import io.skrastrek.aws.lambda.kotlin.core.json
+import io.skrastrek.aws.lambda.kotlin.core.defaultJson
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import kotlin.test.Test
@@ -19,23 +21,23 @@ class SuspendingRequestHandlerTest {
     @Test
     fun `suspending handle decodes, invokes and encodes`() =
         runTest {
-            val input = ByteArrayInputStream(json.encodeToString("hello world").toByteArray())
+            val input = ByteArrayInputStream(defaultJson.encodeToString("hello world").toByteArray())
             val output = ByteArrayOutputStream()
 
             CapitalizeRequestHandler.handle(input, output)
 
-            assertEquals(json.encodeToString("HELLO WORLD"), output.toString(Charsets.UTF_8))
+            assertEquals(defaultJson.encodeToString("HELLO WORLD"), output.toString(Charsets.UTF_8))
         }
 
     @Test
     fun `blocking bridge runs the suspending handler`() {
-        val input = ByteArrayInputStream(json.encodeToString("hello world").toByteArray())
+        val input = ByteArrayInputStream(defaultJson.encodeToString("hello world").toByteArray())
         val output = ByteArrayOutputStream()
 
         // The AWS-facing entry point: this is what the managed Java runtime invokes.
         CapitalizeRequestHandler.handleRequest(input, output, EmptyContext)
 
-        assertEquals(json.encodeToString("HELLO WORLD"), output.toString(Charsets.UTF_8))
+        assertEquals(defaultJson.encodeToString("HELLO WORLD"), output.toString(Charsets.UTF_8))
     }
 
     @Test
@@ -56,6 +58,29 @@ class SuspendingRequestHandlerTest {
 
             assertEquals("payload", output.toString(Charsets.UTF_8))
         }
+
+    @Test
+    fun `an overridden json is honoured on the suspending path`() =
+        runTest {
+            val input = ByteArrayInputStream("""["a","b"]""".toByteArray())
+            val output = ByteArrayOutputStream()
+
+            PrettyPrintingHandler.handle(input, output)
+
+            assertEquals("[\n    \"A\",\n    \"B\"\n]", output.toString(Charsets.UTF_8))
+        }
+}
+
+private object PrettyPrintingHandler : SuspendingRequestHandler<List<String>, List<String>> {
+    override val deserializer get() = ListSerializer(String.serializer())
+    override val serializer get() = ListSerializer(String.serializer())
+
+    override val json = Json(defaultJson) { prettyPrint = true }
+
+    override suspend fun handle(
+        input: List<String>,
+        context: Context,
+    ) = input.map { it.uppercase() }
 }
 
 private object CapitalizeRequestHandler : SuspendingRequestHandler<String, String> {

--- a/events-coroutines/build.gradle.kts
+++ b/events-coroutines/build.gradle.kts
@@ -1,0 +1,7 @@
+dependencies {
+    api(project(":coroutines"))
+    api(project(":events"))
+    implementation(libs.kotlinx.serialization.json)
+    testImplementation(kotlin("test"))
+    testImplementation(libs.kotlinx.coroutines.test)
+}

--- a/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/ApiGatewayAuthorizerV1SuspendingRequestHandler.kt
+++ b/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/ApiGatewayAuthorizerV1SuspendingRequestHandler.kt
@@ -1,0 +1,12 @@
+package io.skrastrek.aws.lambda.kotlin.events.coroutines
+
+import io.skrastrek.aws.lambda.kotlin.coroutines.SuspendingRequestHandler
+import io.skrastrek.aws.lambda.kotlin.events.ApiGatewayAuthorizerV1Event
+import io.skrastrek.aws.lambda.kotlin.events.ApiGatewayAuthorizerV1Result
+
+/** Suspending counterpart to [io.skrastrek.aws.lambda.kotlin.events.ApiGatewayAuthorizerV1RequestHandler]. */
+interface ApiGatewayAuthorizerV1SuspendingRequestHandler :
+    SuspendingRequestHandler<ApiGatewayAuthorizerV1Event, ApiGatewayAuthorizerV1Result> {
+    override val deserializer get() = ApiGatewayAuthorizerV1Event.serializer()
+    override val serializer get() = ApiGatewayAuthorizerV1Result.serializer()
+}

--- a/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/ApiGatewayAuthorizerV1SuspendingRequestHandler.kt
+++ b/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/ApiGatewayAuthorizerV1SuspendingRequestHandler.kt
@@ -3,10 +3,13 @@ package io.skrastrek.aws.lambda.kotlin.events.coroutines
 import io.skrastrek.aws.lambda.kotlin.coroutines.SuspendingRequestHandler
 import io.skrastrek.aws.lambda.kotlin.events.ApiGatewayAuthorizerV1Event
 import io.skrastrek.aws.lambda.kotlin.events.ApiGatewayAuthorizerV1Result
+import io.skrastrek.aws.lambda.kotlin.events.ApiGatewayAuthorizerV1Serializers
 
-/** Suspending counterpart to [io.skrastrek.aws.lambda.kotlin.events.ApiGatewayAuthorizerV1RequestHandler]. */
+/**
+ * Suspending counterpart to [io.skrastrek.aws.lambda.kotlin.events.ApiGatewayAuthorizerV1RequestHandler].
+ *
+ * Serializers come from [ApiGatewayAuthorizerV1Serializers], shared with the blocking interface.
+ */
 interface ApiGatewayAuthorizerV1SuspendingRequestHandler :
-    SuspendingRequestHandler<ApiGatewayAuthorizerV1Event, ApiGatewayAuthorizerV1Result> {
-    override val deserializer get() = ApiGatewayAuthorizerV1Event.serializer()
-    override val serializer get() = ApiGatewayAuthorizerV1Result.serializer()
-}
+    SuspendingRequestHandler<ApiGatewayAuthorizerV1Event, ApiGatewayAuthorizerV1Result>,
+    ApiGatewayAuthorizerV1Serializers

--- a/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/ApiGatewayAuthorizerV2SuspendingRequestHandler.kt
+++ b/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/ApiGatewayAuthorizerV2SuspendingRequestHandler.kt
@@ -1,0 +1,12 @@
+package io.skrastrek.aws.lambda.kotlin.events.coroutines
+
+import io.skrastrek.aws.lambda.kotlin.coroutines.SuspendingRequestHandler
+import io.skrastrek.aws.lambda.kotlin.events.ApiGatewayAuthorizerSimpleResult
+import io.skrastrek.aws.lambda.kotlin.events.ApiGatewayAuthorizerV2Event
+
+/** Suspending counterpart to [io.skrastrek.aws.lambda.kotlin.events.ApiGatewayAuthorizerV2RequestHandler]. */
+interface ApiGatewayAuthorizerV2SuspendingRequestHandler :
+    SuspendingRequestHandler<ApiGatewayAuthorizerV2Event, ApiGatewayAuthorizerSimpleResult> {
+    override val deserializer get() = ApiGatewayAuthorizerV2Event.serializer()
+    override val serializer get() = ApiGatewayAuthorizerSimpleResult.serializer()
+}

--- a/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/ApiGatewayAuthorizerV2SuspendingRequestHandler.kt
+++ b/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/ApiGatewayAuthorizerV2SuspendingRequestHandler.kt
@@ -3,10 +3,13 @@ package io.skrastrek.aws.lambda.kotlin.events.coroutines
 import io.skrastrek.aws.lambda.kotlin.coroutines.SuspendingRequestHandler
 import io.skrastrek.aws.lambda.kotlin.events.ApiGatewayAuthorizerSimpleResult
 import io.skrastrek.aws.lambda.kotlin.events.ApiGatewayAuthorizerV2Event
+import io.skrastrek.aws.lambda.kotlin.events.ApiGatewayAuthorizerV2Serializers
 
-/** Suspending counterpart to [io.skrastrek.aws.lambda.kotlin.events.ApiGatewayAuthorizerV2RequestHandler]. */
+/**
+ * Suspending counterpart to [io.skrastrek.aws.lambda.kotlin.events.ApiGatewayAuthorizerV2RequestHandler].
+ *
+ * Serializers come from [ApiGatewayAuthorizerV2Serializers], shared with the blocking interface.
+ */
 interface ApiGatewayAuthorizerV2SuspendingRequestHandler :
-    SuspendingRequestHandler<ApiGatewayAuthorizerV2Event, ApiGatewayAuthorizerSimpleResult> {
-    override val deserializer get() = ApiGatewayAuthorizerV2Event.serializer()
-    override val serializer get() = ApiGatewayAuthorizerSimpleResult.serializer()
-}
+    SuspendingRequestHandler<ApiGatewayAuthorizerV2Event, ApiGatewayAuthorizerSimpleResult>,
+    ApiGatewayAuthorizerV2Serializers

--- a/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/ApiGatewayProxyV1SuspendingRequestHandler.kt
+++ b/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/ApiGatewayProxyV1SuspendingRequestHandler.kt
@@ -3,9 +3,13 @@ package io.skrastrek.aws.lambda.kotlin.events.coroutines
 import io.skrastrek.aws.lambda.kotlin.coroutines.SuspendingRequestHandler
 import io.skrastrek.aws.lambda.kotlin.events.ApiGatewayProxyV1Event
 import io.skrastrek.aws.lambda.kotlin.events.ApiGatewayProxyV1Result
+import io.skrastrek.aws.lambda.kotlin.events.ApiGatewayProxyV1Serializers
 
-/** Suspending counterpart to [io.skrastrek.aws.lambda.kotlin.events.ApiGatewayProxyV1RequestHandler]. */
-interface ApiGatewayProxyV1SuspendingRequestHandler : SuspendingRequestHandler<ApiGatewayProxyV1Event, ApiGatewayProxyV1Result> {
-    override val deserializer get() = ApiGatewayProxyV1Event.serializer()
-    override val serializer get() = ApiGatewayProxyV1Result.serializer()
-}
+/**
+ * Suspending counterpart to [io.skrastrek.aws.lambda.kotlin.events.ApiGatewayProxyV1RequestHandler].
+ *
+ * Serializers come from [ApiGatewayProxyV1Serializers], shared with the blocking interface.
+ */
+interface ApiGatewayProxyV1SuspendingRequestHandler :
+    SuspendingRequestHandler<ApiGatewayProxyV1Event, ApiGatewayProxyV1Result>,
+    ApiGatewayProxyV1Serializers

--- a/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/ApiGatewayProxyV1SuspendingRequestHandler.kt
+++ b/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/ApiGatewayProxyV1SuspendingRequestHandler.kt
@@ -1,0 +1,11 @@
+package io.skrastrek.aws.lambda.kotlin.events.coroutines
+
+import io.skrastrek.aws.lambda.kotlin.coroutines.SuspendingRequestHandler
+import io.skrastrek.aws.lambda.kotlin.events.ApiGatewayProxyV1Event
+import io.skrastrek.aws.lambda.kotlin.events.ApiGatewayProxyV1Result
+
+/** Suspending counterpart to [io.skrastrek.aws.lambda.kotlin.events.ApiGatewayProxyV1RequestHandler]. */
+interface ApiGatewayProxyV1SuspendingRequestHandler : SuspendingRequestHandler<ApiGatewayProxyV1Event, ApiGatewayProxyV1Result> {
+    override val deserializer get() = ApiGatewayProxyV1Event.serializer()
+    override val serializer get() = ApiGatewayProxyV1Result.serializer()
+}

--- a/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/ApiGatewayProxyV2SuspendingRequestHandler.kt
+++ b/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/ApiGatewayProxyV2SuspendingRequestHandler.kt
@@ -3,9 +3,13 @@ package io.skrastrek.aws.lambda.kotlin.events.coroutines
 import io.skrastrek.aws.lambda.kotlin.coroutines.SuspendingRequestHandler
 import io.skrastrek.aws.lambda.kotlin.events.ApiGatewayProxyV2Event
 import io.skrastrek.aws.lambda.kotlin.events.ApiGatewayProxyV2Result
+import io.skrastrek.aws.lambda.kotlin.events.ApiGatewayProxyV2Serializers
 
-/** Suspending counterpart to [io.skrastrek.aws.lambda.kotlin.events.ApiGatewayProxyV2RequestHandler]. */
-interface ApiGatewayProxyV2SuspendingRequestHandler : SuspendingRequestHandler<ApiGatewayProxyV2Event, ApiGatewayProxyV2Result> {
-    override val deserializer get() = ApiGatewayProxyV2Event.serializer()
-    override val serializer get() = ApiGatewayProxyV2Result.serializer()
-}
+/**
+ * Suspending counterpart to [io.skrastrek.aws.lambda.kotlin.events.ApiGatewayProxyV2RequestHandler].
+ *
+ * Serializers come from [ApiGatewayProxyV2Serializers], shared with the blocking interface.
+ */
+interface ApiGatewayProxyV2SuspendingRequestHandler :
+    SuspendingRequestHandler<ApiGatewayProxyV2Event, ApiGatewayProxyV2Result>,
+    ApiGatewayProxyV2Serializers

--- a/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/ApiGatewayProxyV2SuspendingRequestHandler.kt
+++ b/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/ApiGatewayProxyV2SuspendingRequestHandler.kt
@@ -1,0 +1,11 @@
+package io.skrastrek.aws.lambda.kotlin.events.coroutines
+
+import io.skrastrek.aws.lambda.kotlin.coroutines.SuspendingRequestHandler
+import io.skrastrek.aws.lambda.kotlin.events.ApiGatewayProxyV2Event
+import io.skrastrek.aws.lambda.kotlin.events.ApiGatewayProxyV2Result
+
+/** Suspending counterpart to [io.skrastrek.aws.lambda.kotlin.events.ApiGatewayProxyV2RequestHandler]. */
+interface ApiGatewayProxyV2SuspendingRequestHandler : SuspendingRequestHandler<ApiGatewayProxyV2Event, ApiGatewayProxyV2Result> {
+    override val deserializer get() = ApiGatewayProxyV2Event.serializer()
+    override val serializer get() = ApiGatewayProxyV2Result.serializer()
+}

--- a/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/DynamoDbEventSuspendingRequestHandler.kt
+++ b/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/DynamoDbEventSuspendingRequestHandler.kt
@@ -3,14 +3,13 @@ package io.skrastrek.aws.lambda.kotlin.events.coroutines
 import io.skrastrek.aws.lambda.kotlin.coroutines.SuspendingRequestHandler
 import io.skrastrek.aws.lambda.kotlin.events.BatchEventResponse
 import io.skrastrek.aws.lambda.kotlin.events.DynamoDbEvent
+import io.skrastrek.aws.lambda.kotlin.events.DynamoDbEventSerializers
 
 /**
  * Suspending counterpart to [io.skrastrek.aws.lambda.kotlin.events.DynamoDbEventRequestHandler].
  *
- * The serializer bindings are restated rather than inherited from the blocking interface: the two
- * declare `handle(I, Context)` with and without `suspend`, which cannot coexist in one type.
+ * Serializers come from [DynamoDbEventSerializers], shared with the blocking interface.
  */
-interface DynamoDbEventSuspendingRequestHandler : SuspendingRequestHandler<DynamoDbEvent, BatchEventResponse> {
-    override val deserializer get() = DynamoDbEvent.serializer()
-    override val serializer get() = BatchEventResponse.serializer()
-}
+interface DynamoDbEventSuspendingRequestHandler :
+    SuspendingRequestHandler<DynamoDbEvent, BatchEventResponse>,
+    DynamoDbEventSerializers

--- a/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/DynamoDbEventSuspendingRequestHandler.kt
+++ b/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/DynamoDbEventSuspendingRequestHandler.kt
@@ -1,0 +1,16 @@
+package io.skrastrek.aws.lambda.kotlin.events.coroutines
+
+import io.skrastrek.aws.lambda.kotlin.coroutines.SuspendingRequestHandler
+import io.skrastrek.aws.lambda.kotlin.events.BatchEventResponse
+import io.skrastrek.aws.lambda.kotlin.events.DynamoDbEvent
+
+/**
+ * Suspending counterpart to [io.skrastrek.aws.lambda.kotlin.events.DynamoDbEventRequestHandler].
+ *
+ * The serializer bindings are restated rather than inherited from the blocking interface: the two
+ * declare `handle(I, Context)` with and without `suspend`, which cannot coexist in one type.
+ */
+interface DynamoDbEventSuspendingRequestHandler : SuspendingRequestHandler<DynamoDbEvent, BatchEventResponse> {
+    override val deserializer get() = DynamoDbEvent.serializer()
+    override val serializer get() = BatchEventResponse.serializer()
+}

--- a/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/SqsEventSuspendingRequestHandler.kt
+++ b/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/SqsEventSuspendingRequestHandler.kt
@@ -3,9 +3,13 @@ package io.skrastrek.aws.lambda.kotlin.events.coroutines
 import io.skrastrek.aws.lambda.kotlin.coroutines.SuspendingRequestHandler
 import io.skrastrek.aws.lambda.kotlin.events.BatchEventResponse
 import io.skrastrek.aws.lambda.kotlin.events.SqsEvent
+import io.skrastrek.aws.lambda.kotlin.events.SqsEventSerializers
 
-/** Suspending counterpart to [io.skrastrek.aws.lambda.kotlin.events.SqsEventRequestHandler]. */
-interface SqsEventSuspendingRequestHandler : SuspendingRequestHandler<SqsEvent, BatchEventResponse> {
-    override val deserializer get() = SqsEvent.serializer()
-    override val serializer get() = BatchEventResponse.serializer()
-}
+/**
+ * Suspending counterpart to [io.skrastrek.aws.lambda.kotlin.events.SqsEventRequestHandler].
+ *
+ * Serializers come from [SqsEventSerializers], shared with the blocking interface.
+ */
+interface SqsEventSuspendingRequestHandler :
+    SuspendingRequestHandler<SqsEvent, BatchEventResponse>,
+    SqsEventSerializers

--- a/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/SqsEventSuspendingRequestHandler.kt
+++ b/events-coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/SqsEventSuspendingRequestHandler.kt
@@ -1,0 +1,11 @@
+package io.skrastrek.aws.lambda.kotlin.events.coroutines
+
+import io.skrastrek.aws.lambda.kotlin.coroutines.SuspendingRequestHandler
+import io.skrastrek.aws.lambda.kotlin.events.BatchEventResponse
+import io.skrastrek.aws.lambda.kotlin.events.SqsEvent
+
+/** Suspending counterpart to [io.skrastrek.aws.lambda.kotlin.events.SqsEventRequestHandler]. */
+interface SqsEventSuspendingRequestHandler : SuspendingRequestHandler<SqsEvent, BatchEventResponse> {
+    override val deserializer get() = SqsEvent.serializer()
+    override val serializer get() = BatchEventResponse.serializer()
+}

--- a/events-coroutines/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/DynamoDbEventSuspendingRequestHandlerTest.kt
+++ b/events-coroutines/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/DynamoDbEventSuspendingRequestHandlerTest.kt
@@ -1,0 +1,35 @@
+package io.skrastrek.aws.lambda.kotlin.events.coroutines
+
+import com.amazonaws.services.lambda.runtime.Context
+import io.skrastrek.aws.lambda.kotlin.coroutines.handle
+import io.skrastrek.aws.lambda.kotlin.events.BatchEventResponse
+import io.skrastrek.aws.lambda.kotlin.events.DynamoDbEvent
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DynamoDbEventSuspendingRequestHandlerTest {
+    @Test
+    fun `decodes the event and encodes the batch response`() =
+        runTest {
+            val input = ByteArrayInputStream("""{"Records":[]}""".toByteArray())
+            val output = ByteArrayOutputStream()
+
+            NoFailuresHandler.handle(input, output)
+
+            assertEquals("""{"batchItemFailures":[]}""", output.toString(Charsets.UTF_8))
+        }
+}
+
+private object NoFailuresHandler : DynamoDbEventSuspendingRequestHandler {
+    override suspend fun handle(
+        input: DynamoDbEvent,
+        context: Context,
+    ): BatchEventResponse {
+        delay(1)
+        return BatchEventResponse(emptyList())
+    }
+}

--- a/events-coroutines/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/SharedSerializersTest.kt
+++ b/events-coroutines/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/events/coroutines/SharedSerializersTest.kt
@@ -1,0 +1,59 @@
+package io.skrastrek.aws.lambda.kotlin.events.coroutines
+
+import com.amazonaws.services.lambda.runtime.Context
+import io.skrastrek.aws.lambda.kotlin.core.handle
+import io.skrastrek.aws.lambda.kotlin.coroutines.handle
+import io.skrastrek.aws.lambda.kotlin.events.BatchEventResponse
+import io.skrastrek.aws.lambda.kotlin.events.BatchItemFailure
+import io.skrastrek.aws.lambda.kotlin.events.DynamoDbEvent
+import io.skrastrek.aws.lambda.kotlin.events.DynamoDbEventRequestHandler
+import kotlinx.coroutines.test.runTest
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The blocking and suspending interfaces for an event both mix in the same `…Serializers`
+ * interface, so the serializer pair is declared once. This pins that down: drift between the two
+ * would show up as differing output for identical input.
+ */
+class SharedSerializersTest {
+    private val event = """{"Records":[]}"""
+    private val expected = """{"batchItemFailures":[{"itemIdentifier":"id-1"}]}"""
+
+    @Test
+    fun `blocking handler encodes via the shared serializers`() {
+        val output = ByteArrayOutputStream()
+
+        Blocking.handle(ByteArrayInputStream(event.toByteArray()), output)
+
+        assertEquals(expected, output.toString(Charsets.UTF_8))
+    }
+
+    @Test
+    fun `suspending handler encodes identically`() =
+        runTest {
+            val output = ByteArrayOutputStream()
+
+            Suspending.handle(ByteArrayInputStream(event.toByteArray()), output)
+
+            assertEquals(expected, output.toString(Charsets.UTF_8))
+        }
+}
+
+private val oneFailure = BatchEventResponse(listOf(BatchItemFailure("id-1")))
+
+private object Blocking : DynamoDbEventRequestHandler {
+    override fun handle(
+        input: DynamoDbEvent,
+        context: Context,
+    ) = oneFailure
+}
+
+private object Suspending : DynamoDbEventSuspendingRequestHandler {
+    override suspend fun handle(
+        input: DynamoDbEvent,
+        context: Context,
+    ) = oneFailure
+}

--- a/events/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/ApiGatewayAuthorizerV1Event.kt
+++ b/events/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/ApiGatewayAuthorizerV1Event.kt
@@ -1,5 +1,6 @@
 package io.skrastrek.aws.lambda.kotlin.events
 
+import io.skrastrek.aws.lambda.kotlin.core.HandlerSerializers
 import io.skrastrek.aws.lambda.kotlin.core.RequestHandler
 import kotlinx.serialization.Serializable
 
@@ -8,10 +9,14 @@ import kotlinx.serialization.Serializable
  * https://github.com/aws/aws-lambda-java-libs/blob/main/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayCustomAuthorizerEvent.java
  */
 
-interface ApiGatewayAuthorizerV1RequestHandler : RequestHandler<ApiGatewayAuthorizerV1Event, ApiGatewayAuthorizerV1Result> {
+interface ApiGatewayAuthorizerV1Serializers : HandlerSerializers<ApiGatewayAuthorizerV1Event, ApiGatewayAuthorizerV1Result> {
     override val deserializer get() = ApiGatewayAuthorizerV1Event.serializer()
     override val serializer get() = ApiGatewayAuthorizerV1Result.serializer()
 }
+
+interface ApiGatewayAuthorizerV1RequestHandler :
+    RequestHandler<ApiGatewayAuthorizerV1Event, ApiGatewayAuthorizerV1Result>,
+    ApiGatewayAuthorizerV1Serializers
 
 @Serializable
 data class ApiGatewayAuthorizerV1Event(

--- a/events/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/ApiGatewayAuthorizerV2Event.kt
+++ b/events/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/ApiGatewayAuthorizerV2Event.kt
@@ -1,5 +1,6 @@
 package io.skrastrek.aws.lambda.kotlin.events
 
+import io.skrastrek.aws.lambda.kotlin.core.HandlerSerializers
 import io.skrastrek.aws.lambda.kotlin.core.RequestHandler
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
@@ -9,10 +10,14 @@ import kotlinx.serialization.json.JsonObject
  * https://github.com/aws/aws-lambda-java-libs/blob/master/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayV2CustomAuthorizerEvent.java
  */
 
-interface ApiGatewayAuthorizerV2RequestHandler : RequestHandler<ApiGatewayAuthorizerV2Event, ApiGatewayAuthorizerSimpleResult> {
+interface ApiGatewayAuthorizerV2Serializers : HandlerSerializers<ApiGatewayAuthorizerV2Event, ApiGatewayAuthorizerSimpleResult> {
     override val deserializer get() = ApiGatewayAuthorizerV2Event.serializer()
     override val serializer get() = ApiGatewayAuthorizerSimpleResult.serializer()
 }
+
+interface ApiGatewayAuthorizerV2RequestHandler :
+    RequestHandler<ApiGatewayAuthorizerV2Event, ApiGatewayAuthorizerSimpleResult>,
+    ApiGatewayAuthorizerV2Serializers
 
 @Serializable
 data class ApiGatewayAuthorizerV2Event(

--- a/events/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/ApiGatewayProxyV1Event.kt
+++ b/events/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/ApiGatewayProxyV1Event.kt
@@ -1,13 +1,18 @@
 package io.skrastrek.aws.lambda.kotlin.events
 
+import io.skrastrek.aws.lambda.kotlin.core.HandlerSerializers
 import io.skrastrek.aws.lambda.kotlin.core.RequestHandler
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 
-interface ApiGatewayProxyV1RequestHandler : RequestHandler<ApiGatewayProxyV1Event, ApiGatewayProxyV1Result> {
+interface ApiGatewayProxyV1Serializers : HandlerSerializers<ApiGatewayProxyV1Event, ApiGatewayProxyV1Result> {
     override val deserializer get() = ApiGatewayProxyV1Event.serializer()
     override val serializer get() = ApiGatewayProxyV1Result.serializer()
 }
+
+interface ApiGatewayProxyV1RequestHandler :
+    RequestHandler<ApiGatewayProxyV1Event, ApiGatewayProxyV1Result>,
+    ApiGatewayProxyV1Serializers
 
 @Serializable
 data class ApiGatewayProxyV1Event(

--- a/events/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/ApiGatewayProxyV2Event.kt
+++ b/events/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/ApiGatewayProxyV2Event.kt
@@ -1,5 +1,6 @@
 package io.skrastrek.aws.lambda.kotlin.events
 
+import io.skrastrek.aws.lambda.kotlin.core.HandlerSerializers
 import io.skrastrek.aws.lambda.kotlin.core.RequestHandler
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
@@ -9,10 +10,14 @@ import kotlinx.serialization.json.JsonObject
  * https://github.com/aws/aws-lambda-java-libs/blob/master/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayV2HTTPEvent.java
  */
 
-interface ApiGatewayProxyV2RequestHandler : RequestHandler<ApiGatewayProxyV2Event, ApiGatewayProxyV2Result> {
+interface ApiGatewayProxyV2Serializers : HandlerSerializers<ApiGatewayProxyV2Event, ApiGatewayProxyV2Result> {
     override val deserializer get() = ApiGatewayProxyV2Event.serializer()
     override val serializer get() = ApiGatewayProxyV2Result.serializer()
 }
+
+interface ApiGatewayProxyV2RequestHandler :
+    RequestHandler<ApiGatewayProxyV2Event, ApiGatewayProxyV2Result>,
+    ApiGatewayProxyV2Serializers
 
 @Serializable
 data class ApiGatewayProxyV2Event(

--- a/events/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/DynamoDbEvent.kt
+++ b/events/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/DynamoDbEvent.kt
@@ -1,13 +1,18 @@
 package io.skrastrek.aws.lambda.kotlin.events
 
+import io.skrastrek.aws.lambda.kotlin.core.HandlerSerializers
 import io.skrastrek.aws.lambda.kotlin.core.RequestHandler
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-interface DynamoDbEventRequestHandler : RequestHandler<DynamoDbEvent, BatchEventResponse> {
+interface DynamoDbEventSerializers : HandlerSerializers<DynamoDbEvent, BatchEventResponse> {
     override val deserializer get() = DynamoDbEvent.serializer()
     override val serializer get() = BatchEventResponse.serializer()
 }
+
+interface DynamoDbEventRequestHandler :
+    RequestHandler<DynamoDbEvent, BatchEventResponse>,
+    DynamoDbEventSerializers
 
 @Serializable
 data class DynamoDbEvent(

--- a/events/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/SqsEvent.kt
+++ b/events/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/events/SqsEvent.kt
@@ -1,13 +1,18 @@
 package io.skrastrek.aws.lambda.kotlin.events
 
+import io.skrastrek.aws.lambda.kotlin.core.HandlerSerializers
 import io.skrastrek.aws.lambda.kotlin.core.RequestHandler
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-interface SqsEventRequestHandler : RequestHandler<SqsEvent, BatchEventResponse> {
+interface SqsEventSerializers : HandlerSerializers<SqsEvent, BatchEventResponse> {
     override val deserializer get() = SqsEvent.serializer()
     override val serializer get() = BatchEventResponse.serializer()
 }
+
+interface SqsEventRequestHandler :
+    RequestHandler<SqsEvent, BatchEventResponse>,
+    SqsEventSerializers
 
 @Serializable
 data class SqsEvent(

--- a/events/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/events/ApiGatewayProxyV1EventTest.kt
+++ b/events/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/events/ApiGatewayProxyV1EventTest.kt
@@ -1,6 +1,6 @@
 package io.skrastrek.aws.lambda.kotlin.events
 
-import io.skrastrek.aws.lambda.kotlin.core.json
+import io.skrastrek.aws.lambda.kotlin.core.defaultJson
 import kotlinx.serialization.ExperimentalSerializationApi
 import org.junit.jupiter.api.Test
 
@@ -8,6 +8,6 @@ import org.junit.jupiter.api.Test
 class ApiGatewayProxyV1EventTest {
     @Test
     fun decode_1() {
-        json.decodeFromResource<ApiGatewayProxyV1Event>("api-gw-proxy-v1-event-1.json")
+        defaultJson.decodeFromResource<ApiGatewayProxyV1Event>("api-gw-proxy-v1-event-1.json")
     }
 }

--- a/events/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/events/DynamoDbEventTest.kt
+++ b/events/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/events/DynamoDbEventTest.kt
@@ -1,6 +1,6 @@
 package io.skrastrek.aws.lambda.kotlin.events
 
-import io.skrastrek.aws.lambda.kotlin.core.json
+import io.skrastrek.aws.lambda.kotlin.core.defaultJson
 import kotlinx.serialization.ExperimentalSerializationApi
 import org.junit.jupiter.api.Test
 
@@ -8,11 +8,11 @@ import org.junit.jupiter.api.Test
 class DynamoDbEventTest {
     @Test
     fun decode_1() {
-        json.decodeFromResource<DynamoDbEvent>("dynamodb-event-1.json")
+        defaultJson.decodeFromResource<DynamoDbEvent>("dynamodb-event-1.json")
     }
 
     @Test
     fun decode_2() {
-        json.decodeFromResource<DynamoDbEvent>("dynamodb-event-2.json")
+        defaultJson.decodeFromResource<DynamoDbEvent>("dynamodb-event-2.json")
     }
 }

--- a/events/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/events/SqsEventTest.kt
+++ b/events/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/events/SqsEventTest.kt
@@ -1,6 +1,6 @@
 package io.skrastrek.aws.lambda.kotlin.events
 
-import io.skrastrek.aws.lambda.kotlin.core.json
+import io.skrastrek.aws.lambda.kotlin.core.defaultJson
 import kotlinx.serialization.ExperimentalSerializationApi
 import org.junit.jupiter.api.Test
 
@@ -8,11 +8,11 @@ import org.junit.jupiter.api.Test
 class SqsEventTest {
     @Test
     fun decode_1() {
-        json.decodeFromResource<SqsEvent>("sqs-event-1.json")
+        defaultJson.decodeFromResource<SqsEvent>("sqs-event-1.json")
     }
 
     @Test
     fun decode_2() {
-        json.decodeFromResource<SqsEvent>("sqs-event-2.json")
+        defaultJson.decodeFromResource<SqsEvent>("sqs-event-2.json")
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,5 +4,6 @@ include(
     "core",
     "coroutines",
     "events",
+    "events-coroutines",
     "runtime"
 )


### PR DESCRIPTION
Follow-up to #78. Three related changes, all converging on `HandlerSerializers` as the single place a handler's serialization is described.

## ⚠️ Breaking change

The top-level `json` in `:core` is renamed **`defaultJson`**. It had to stop colliding with the new `json` member described below — otherwise an override could not reference the base instance without shadowing itself. Rides the major bump already in flight for #77/#78.

## 1. Suspending handler interfaces for events

The `events` module ships six blocking handler interfaces but had no suspending counterparts, so consumers of `SuspendingRequestHandler` had to restate the serializer pair for every event type. Adds `:events-coroutines`, published as `aws-lambda-kotlin-events-coroutines`:

```kotlin
object MyHandler : DynamoDbEventSuspendingRequestHandler {
    override suspend fun handle(input: DynamoDbEvent, context: Context): BatchEventResponse {
        val failures = input.records.map { async { process(it) } }.awaitAll()
        return BatchEventResponse(failures.filterNotNull())
    }
}
```

Concurrent partial-batch processing is the main thing this unlocks.

**Why a separate module.** Putting these in `:events` would require `:coroutines` on its api classpath, placing 1.5 MB of `kotlinx-coroutines-core` in front of every consumer writing plain blocking handlers — the cost the module split in #78 exists to avoid. The reverse is worse: `:runtime` depends on `:coroutines`, so every custom-runtime user would pull in all the event models.

```
core
├── events ─────────────────┐
└── coroutines ─────────────┤
      ├── runtime           │
      └── events-coroutines ┘
```

## 2. Shared serializer bindings

`HandlerSerializers<I, O>` is new in `:core` and is a supertype of **both** `RequestHandler` and `SuspendingRequestHandler`, so an event states its serializers once:

```kotlin
// events — the only place these serializers are named
interface DynamoDbEventSerializers : HandlerSerializers<DynamoDbEvent, BatchEventResponse> {
    override val deserializer get() = DynamoDbEvent.serializer()
    override val serializer get() = BatchEventResponse.serializer()
}

// events
interface DynamoDbEventRequestHandler :
    RequestHandler<DynamoDbEvent, BatchEventResponse>, DynamoDbEventSerializers

// events-coroutines
interface DynamoDbEventSuspendingRequestHandler :
    SuspendingRequestHandler<DynamoDbEvent, BatchEventResponse>, DynamoDbEventSerializers
```

The per-style interfaces now have empty bodies. `events-coroutines` contains zero serializer lines.

An earlier attempt put the bindings in an *unrelated* interface with the same member names, and the compiler rejected it — `must override 'deserializer' because it inherits multiple interface methods for it`. Two independent declarations give Kotlin nothing to resolve to; routing both styles through one `HandlerSerializers` makes it an ordinary diamond with a single implementation.

## 3. Overridable JSON configuration

`HandlerSerializers` also carries an overridable `json`, defaulting to `defaultJson`:

```kotlin
override val json = Json(defaultJson) {
    serializersModule = SerializersModule {
        contextual(ApiGatewayProxyV1Event::class, ApiGatewayProxyV1Event.serializer())
    }
}
```

Registering serializers explicitly through a module keeps lookup off the reflective path that a GraalVM native image cannot follow without extra configuration.

It lives on `HandlerSerializers` for the same reason the serializer bindings do: an event's `…Serializers` interface can set the configuration once and both the blocking and suspending handlers pick it up.

**One gotcha, documented on the member:** `Json(defaultJson) { … }` copies the base configuration, but assigning `serializersModule` *replaces* it rather than adding to it. To preserve an existing module, combine them — `serializersModule = defaultJson.serializersModule + SerializersModule { … }`.

## Compatibility

Apart from the `json` → `defaultJson` rename, this is source-compatible. Per-event interface names are unchanged, and `RequestHandler` still exposes `deserializer`/`serializer` — now inherited rather than declared.

## Tests

22 tests across five modules, all passing; `./gradlew build` clean including ktlint. New coverage:

- a smoke test through `DynamoDbEventSuspendingRequestHandler`
- `SharedSerializersTest` drives a blocking and a suspending handler over identical input and asserts identical bytes, so drift between the two bindings fails the build
- `HandlerJsonTest` proves an overridden `json` supplies a contextual serializer end-to-end, **and** that the default configuration fails without it — so the hook is load-bearing rather than incidentally passing
- a matching check that the suspending decode/encode path honours the override too

`:core` now applies the serialization plugin so its tests can declare `@Serializable` fixtures; no main-source `@Serializable` types were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)