### PR TITLE
Infer handler serializers from type arguments

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,5 +1,11 @@
+plugins {
+    alias(libs.plugins.kotlin.serialization)
+}
+
 dependencies {
     api(libs.aws.lambda.java.core)
+    // Build-time only: read by native-image when building a GraalVM image, absent at runtime.
+    compileOnly(libs.graalvm.nativeimage)
     implementation(libs.kotlinx.serialization.json)
     testImplementation(kotlin("test"))
 }

--- a/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/RequestHandler.kt
+++ b/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/RequestHandler.kt
@@ -23,18 +23,27 @@ val json =
 
 interface RequestHandler<I : Any, O : Any> : RequestStreamHandler {
     /**
+     * The [Json] used on the wire. Override to change its configuration, or to register contextual
+     * serializers — which is also how to keep serializer lookup reflection-free, see
+     * [SerializerInference].
+     */
+    val json: Json get() = io.skrastrek.aws.lambda.kotlin.core.json
+
+    /**
      * Reads [I] off the wire. Defaults to the serializer for whatever [I] is bound to by the
      * implementing class, so `RequestHandler<Foo, Bar>` needs no declaration here. Override to use a
      * different strategy, or when the binding is not concrete — see [SerializerInference].
      */
     @Suppress("UNCHECKED_CAST")
     val deserializer: DeserializationStrategy<I>
-        get() = SerializerInference.serializersOf(this, RequestHandler::class.java)[0] as DeserializationStrategy<I>
+        get() = inferredSerializers()[0] as DeserializationStrategy<I>
 
     /** Writes [O] to the wire. Inferred like [deserializer]. */
     @Suppress("UNCHECKED_CAST")
     val serializer: SerializationStrategy<O>
-        get() = SerializerInference.serializersOf(this, RequestHandler::class.java)[1] as SerializationStrategy<O>
+        get() = inferredSerializers()[1] as SerializationStrategy<O>
+
+    private fun inferredSerializers() = SerializerInference.serializersOf(javaClass, RequestHandler::class.java, json.serializersModule)
 
     fun handle(
         input: I,

--- a/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/RequestHandler.kt
+++ b/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/RequestHandler.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
+import kotlinx.serialization.serializer
 import java.io.InputStream
 import java.io.OutputStream
 
@@ -21,8 +22,19 @@ val json =
     }
 
 interface RequestHandler<I : Any, O : Any> : RequestStreamHandler {
+    /**
+     * Reads [I] off the wire. Defaults to the serializer for whatever [I] is bound to by the
+     * implementing class, so `RequestHandler<Foo, Bar>` needs no declaration here. Override to use a
+     * different strategy, or when the binding is not concrete — see [SerializerInference].
+     */
+    @Suppress("UNCHECKED_CAST")
     val deserializer: DeserializationStrategy<I>
+        get() = SerializerInference.serializersOf(this, RequestHandler::class.java)[0] as DeserializationStrategy<I>
+
+    /** Writes [O] to the wire. Inferred like [deserializer]. */
+    @Suppress("UNCHECKED_CAST")
     val serializer: SerializationStrategy<O>
+        get() = SerializerInference.serializersOf(this, RequestHandler::class.java)[1] as SerializationStrategy<O>
 
     fun handle(
         input: I,
@@ -42,6 +54,25 @@ interface RequestHandler<I : Any, O : Any> : RequestStreamHandler {
     @OptIn(ExperimentalSerializationApi::class)
     private fun O.jsonEncodeTo(output: OutputStream) = json.encodeToStream(serializer, this, output)
 }
+
+/**
+ * A [RequestHandler] built from [handle].
+ *
+ * The serializers come from the reified type arguments, which the serialization plugin resolves at
+ * the call site — no reflection, unlike the inferred defaults on the interface. Use this for
+ * handlers the custom runtime constructs itself; the AWS managed runtime resolves handlers by class
+ * name and needs a named class implementing [RequestHandler] instead.
+ */
+inline fun <reified I : Any, reified O : Any> RequestHandler(crossinline handle: (input: I, context: Context) -> O): RequestHandler<I, O> =
+    object : RequestHandler<I, O> {
+        override val deserializer = serializer<I>()
+        override val serializer = serializer<O>()
+
+        override fun handle(
+            input: I,
+            context: Context,
+        ): O = handle(input, context)
+    }
 
 fun <I : Any, O : Any> RequestHandler<I, O>.handle(input: I): O = handle(input, EmptyContext)
 

--- a/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/SerializerInference.kt
+++ b/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/SerializerInference.kt
@@ -1,6 +1,7 @@
 package io.skrastrek.aws.lambda.kotlin.core
 
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
@@ -19,33 +20,48 @@ import java.util.concurrent.ConcurrentHashMap
  * Unit>` erases `T` and cannot be inferred — such a handler has to override the serializers, or be
  * built through one of the `RequestHandler { ... }` factories, whose reified type parameters resolve
  * at the call site instead.
+ *
+ * ### GraalVM
+ *
+ * Reading the generic signature works in a native image unaided, but finding a class's generated
+ * serializer is reflective and needs registration. `RequestHandlerFeature`, shipped in this artifact
+ * and picked up automatically by `native-image`, registers it for every handler it finds reachable.
+ * Where that is not enough — a handler the analysis cannot see, or type arguments this cannot infer
+ * — register the serializer as contextual instead and no reflection is involved at all:
+ *
+ * ```kotlin
+ * override val json = Json(io.skrastrek.aws.lambda.kotlin.core.json) {
+ *     serializersModule = SerializersModule { contextual(SqsEvent::class, SqsEvent.serializer()) }
+ * }
+ * ```
  */
 object SerializerInference {
     private val cache = ConcurrentHashMap<Key, List<KSerializer<Any>>>()
 
     /**
-     * Serializers for the type arguments [handler] passes to [handlerInterface], in declaration
-     * order. Reflection runs once per handler class; later calls are a map lookup.
+     * Serializers for the type arguments [implementation] passes to [handlerInterface], in
+     * declaration order. [serializersModule] is consulted for contextual serializers before falling
+     * back to reflection. Resolution runs once per handler class; later calls are a map lookup.
      */
     fun serializersOf(
-        handler: Any,
+        implementation: Class<*>,
         handlerInterface: Class<*>,
+        serializersModule: SerializersModule,
     ): List<KSerializer<Any>> =
-        cache.computeIfAbsent(Key(handler.javaClass, handlerInterface)) { (implementation, target) ->
-            typeArgumentsOf(implementation, target).map { argument ->
-                serializer(argument.concreteOrFail(implementation, target))
+        cache.computeIfAbsent(Key(implementation, handlerInterface, serializersModule)) { key ->
+            typeArgumentsOf(key.implementation, key.handlerInterface).map { argument ->
+                key.serializersModule.serializer(argument.concreteOrFail(key.implementation, key.handlerInterface))
             }
         }
 
-    private data class Key(
-        val implementation: Class<*>,
-        val handlerInterface: Class<*>,
-    )
-
-    /** The arguments [implementation] passes to [target], resolved through any intermediate types. */
-    private fun typeArgumentsOf(
+    /**
+     * The type arguments [implementation] passes to [handlerInterface], resolved through any
+     * intermediate types. Exposed for `RequestHandlerFeature`, which needs the types at image build
+     * time without instantiating the handler.
+     */
+    fun typeArgumentsOf(
         implementation: Class<*>,
-        target: Class<*>,
+        handlerInterface: Class<*>,
     ): List<Type> {
         fun search(
             type: Type,
@@ -68,7 +84,7 @@ object SerializerInference {
                     return null
                 }
             }
-            if (raw == target) return arguments
+            if (raw == handlerInterface) return arguments
 
             val inherited: Map<TypeVariable<*>, Type> =
                 raw.typeParameters
@@ -79,8 +95,14 @@ object SerializerInference {
         }
 
         return search(implementation, emptyMap())
-            ?: error("${implementation.name} does not implement ${target.name}.")
+            ?: error("${implementation.name} does not implement ${handlerInterface.name}.")
     }
+
+    private data class Key(
+        val implementation: Class<*>,
+        val handlerInterface: Class<*>,
+        val serializersModule: SerializersModule,
+    )
 
     /** Replaces type variables with what the subtype bound them to, as far as the bindings reach. */
     private fun Type.substitute(bindings: Map<TypeVariable<*>, Type>): Type =
@@ -92,14 +114,14 @@ object SerializerInference {
 
     private fun Type.concreteOrFail(
         implementation: Class<*>,
-        target: Class<*>,
+        handlerInterface: Class<*>,
     ): Type =
         also {
             if (it is TypeVariable<*>) {
                 error(
-                    "${implementation.name} leaves ${target.simpleName}'s type argument '${it.name}' generic, " +
-                        "so its serializer cannot be inferred. Override the serializers explicitly, or build the " +
-                        "handler through the ${target.simpleName} { ... } factory.",
+                    "${implementation.name} leaves ${handlerInterface.simpleName}'s type argument '${it.name}' " +
+                        "generic, so its serializer cannot be inferred. Override the serializers explicitly, or " +
+                        "build the handler through the ${handlerInterface.simpleName} { ... } factory.",
                 )
             }
         }

--- a/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/SerializerInference.kt
+++ b/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/SerializerInference.kt
@@ -1,0 +1,106 @@
+package io.skrastrek.aws.lambda.kotlin.core
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.serializer
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import java.lang.reflect.TypeVariable
+import java.lang.reflect.WildcardType
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Derives serializers from the type arguments a handler class fills in for a handler interface.
+ *
+ * This is what lets `RequestHandler<Foo, Bar>` be implemented without restating `Foo.serializer()`
+ * and `Bar.serializer()`: a class that names its type arguments records them in its generic
+ * signature, so they can be read back at runtime and handed to `kotlinx.serialization`.
+ *
+ * The arguments must be concrete at the implementing class. `class Handler<T> : RequestHandler<T,
+ * Unit>` erases `T` and cannot be inferred — such a handler has to override the serializers, or be
+ * built through one of the `RequestHandler { ... }` factories, whose reified type parameters resolve
+ * at the call site instead.
+ */
+object SerializerInference {
+    private val cache = ConcurrentHashMap<Key, List<KSerializer<Any>>>()
+
+    /**
+     * Serializers for the type arguments [handler] passes to [handlerInterface], in declaration
+     * order. Reflection runs once per handler class; later calls are a map lookup.
+     */
+    fun serializersOf(
+        handler: Any,
+        handlerInterface: Class<*>,
+    ): List<KSerializer<Any>> =
+        cache.computeIfAbsent(Key(handler.javaClass, handlerInterface)) { (implementation, target) ->
+            typeArgumentsOf(implementation, target).map { argument ->
+                serializer(argument.concreteOrFail(implementation, target))
+            }
+        }
+
+    private data class Key(
+        val implementation: Class<*>,
+        val handlerInterface: Class<*>,
+    )
+
+    /** The arguments [implementation] passes to [target], resolved through any intermediate types. */
+    private fun typeArgumentsOf(
+        implementation: Class<*>,
+        target: Class<*>,
+    ): List<Type> {
+        fun search(
+            type: Type,
+            bindings: Map<TypeVariable<*>, Type>,
+        ): List<Type>? {
+            val raw: Class<*>
+            val arguments: List<Type>
+            when (type) {
+                is Class<*> -> {
+                    raw = type
+                    arguments = emptyList()
+                }
+
+                is ParameterizedType -> {
+                    raw = type.rawType as? Class<*> ?: return null
+                    arguments = type.actualTypeArguments.map { it.substitute(bindings) }
+                }
+
+                else -> {
+                    return null
+                }
+            }
+            if (raw == target) return arguments
+
+            val inherited: Map<TypeVariable<*>, Type> =
+                raw.typeParameters
+                    .zip(arguments) { parameter, argument -> (parameter as TypeVariable<*>) to argument }
+                    .toMap()
+            return (listOfNotNull(raw.genericSuperclass) + raw.genericInterfaces)
+                .firstNotNullOfOrNull { search(it, inherited) }
+        }
+
+        return search(implementation, emptyMap())
+            ?: error("${implementation.name} does not implement ${target.name}.")
+    }
+
+    /** Replaces type variables with what the subtype bound them to, as far as the bindings reach. */
+    private fun Type.substitute(bindings: Map<TypeVariable<*>, Type>): Type =
+        when (this) {
+            is TypeVariable<*> -> bindings[this]?.substitute(bindings) ?: this
+            is WildcardType -> upperBounds.firstOrNull()?.substitute(bindings) ?: this
+            else -> this
+        }
+
+    private fun Type.concreteOrFail(
+        implementation: Class<*>,
+        target: Class<*>,
+    ): Type =
+        also {
+            if (it is TypeVariable<*>) {
+                error(
+                    "${implementation.name} leaves ${target.simpleName}'s type argument '${it.name}' generic, " +
+                        "so its serializer cannot be inferred. Override the serializers explicitly, or build the " +
+                        "handler through the ${target.simpleName} { ... } factory.",
+                )
+            }
+        }
+}

--- a/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/graalvm/RequestHandlerFeature.kt
+++ b/core/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/core/graalvm/RequestHandlerFeature.kt
@@ -1,0 +1,99 @@
+package io.skrastrek.aws.lambda.kotlin.core.graalvm
+
+import io.skrastrek.aws.lambda.kotlin.core.SerializerInference
+import org.graalvm.nativeimage.hosted.Feature
+import org.graalvm.nativeimage.hosted.RuntimeReflection
+import java.lang.reflect.Modifier
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+/**
+ * Makes inferred serializers work in a GraalVM native image.
+ *
+ * A handler's type arguments can be read from its generic signature in a native image unaided, but
+ * `kotlinx.serialization` then finds the generated serializer for those types reflectively — through
+ * `Companion` fields and `$serializer` classes the analysis has no reason to keep. This registers
+ * them for every handler the analysis finds reachable, so no consumer configuration is needed.
+ *
+ * `native-image` discovers this class through `META-INF/native-image/.../native-image.properties` in
+ * this artifact. It runs only at image build time; the GraalVM SDK it compiles against is a
+ * `compileOnly` dependency and is absent at runtime.
+ */
+class RequestHandlerFeature : Feature {
+    override fun getDescription() = "Registers serializer lookup metadata for aws-lambda-kotlin request handlers"
+
+    override fun beforeAnalysis(access: Feature.BeforeAnalysisAccess) {
+        HANDLER_INTERFACES
+            .mapNotNull { access.findClassByName(it) }
+            .forEach { handlerInterface ->
+                access.registerSubtypeReachabilityHandler(
+                    { _, implementation -> register(implementation, handlerInterface) },
+                    handlerInterface,
+                )
+            }
+    }
+
+    private fun register(
+        implementation: Class<*>,
+        handlerInterface: Class<*>,
+    ) {
+        if (implementation.isInterface || Modifier.isAbstract(implementation.modifiers)) return
+
+        // A handler whose arguments cannot be inferred is not an error here: it either declares its
+        // serializers explicitly, or fails at runtime with a message of its own.
+        val arguments =
+            runCatching { SerializerInference.typeArgumentsOf(implementation, handlerInterface) }
+                .getOrElse { return }
+
+        arguments.forEach { registerSerializerLookup(it) }
+    }
+
+    private fun registerSerializerLookup(type: Type) {
+        when (type) {
+            is Class<*> -> {
+                registerSerializableClass(type)
+            }
+
+            is ParameterizedType -> {
+                registerSerializerLookup(type.rawType)
+                type.actualTypeArguments.forEach { registerSerializerLookup(it) }
+            }
+
+            else -> {
+                Unit
+            }
+        }
+    }
+
+    /**
+     * Registers the shapes `kotlinx.serialization` probes for: the `Companion` field on the class,
+     * the `serializer` method on the companion, and the `INSTANCE` field of a generated
+     * `$serializer` or a serializable object.
+     *
+     * Members are registered individually rather than only through the `registerAllDeclared*`
+     * queries: those make a member visible to `getDeclaredMethods`, but invoking one that was never
+     * registered itself still fails.
+     */
+    private fun registerSerializableClass(type: Class<*>) {
+        RuntimeReflection.register(type)
+        RuntimeReflection.registerAllDeclaredFields(type)
+        RuntimeReflection.registerAllDeclaredClasses(type)
+        RuntimeReflection.register(*type.declaredFields)
+
+        type.declaredClasses.forEach { nested ->
+            RuntimeReflection.register(nested)
+            RuntimeReflection.registerAllDeclaredFields(nested)
+            RuntimeReflection.registerAllDeclaredMethods(nested)
+            RuntimeReflection.register(*nested.declaredFields)
+            RuntimeReflection.register(*nested.declaredMethods)
+        }
+    }
+
+    private companion object {
+        val HANDLER_INTERFACES =
+            listOf(
+                "io.skrastrek.aws.lambda.kotlin.core.RequestHandler",
+                "io.skrastrek.aws.lambda.kotlin.coroutines.SuspendingRequestHandler",
+            )
+    }
+}

--- a/core/src/main/resources/META-INF/native-image/io.skrastrek/aws-lambda-kotlin-core/native-image.properties
+++ b/core/src/main/resources/META-INF/native-image/io.skrastrek/aws-lambda-kotlin-core/native-image.properties
@@ -1,0 +1,1 @@
+Args = --features=io.skrastrek.aws.lambda.kotlin.core.graalvm.RequestHandlerFeature

--- a/core/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/core/RequestHandlerTest.kt
+++ b/core/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/core/RequestHandlerTest.kt
@@ -6,18 +6,54 @@ import kotlinx.serialization.encodeToString
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class RequestHandlerTest {
     @Test
     fun handle_request() {
-        val input = ByteArrayInputStream(json.encodeToString("hello world").toByteArray())
-        val output = ByteArrayOutputStream()
-
-        CapitalizeRequestHandler.handle(input, output)
-
-        assertEquals(json.encodeToString("HELLO WORLD"), output.toString(Charsets.UTF_8))
+        assertEquals(json.encodeToString("HELLO WORLD"), CapitalizeRequestHandler.handleJson("hello world"))
     }
+
+    @Test
+    fun handle_request_with_inferred_serializers() {
+        assertEquals(json.encodeToString("HELLO WORLD"), InferredCapitalizeRequestHandler.handleJson("hello world"))
+    }
+
+    @Test
+    fun handle_request_with_inferred_serializers_through_a_base_class() {
+        assertEquals(json.encodeToString(11), CountCharactersRequestHandler.handleJson("hello world"))
+    }
+
+    @Test
+    fun handle_request_with_inferred_serializers_for_parameterized_types() {
+        // Kotlin's declaration-site variance emits `List<? extends String>` into the signature.
+        assertEquals(
+            json.encodeToString(mapOf("hello" to 5, "world" to 5)),
+            MeasureEachRequestHandler.handleJson(listOf("hello", "world")),
+        )
+    }
+
+    @Test
+    fun handle_request_from_factory() {
+        val handler = RequestHandler<String, Int> { input, _ -> input.length }
+
+        assertEquals(json.encodeToString(11), handler.handleJson("hello world"))
+    }
+
+    @Test
+    fun inferring_serializers_fails_for_a_generic_handler() {
+        val failure = assertFailsWith<IllegalStateException> { EchoRequestHandler<String>().handleJson("hello world") }
+
+        assertContains(failure.message.orEmpty(), "leaves RequestHandler's type argument 'T' generic")
+    }
+}
+
+private inline fun <reified I : Any, O : Any> RequestHandler<I, O>.handleJson(input: I): String {
+    val output = ByteArrayOutputStream()
+    handle(ByteArrayInputStream(json.encodeToString(input).toByteArray()), output)
+    return output.toString(Charsets.UTF_8)
 }
 
 private object CapitalizeRequestHandler : RequestHandler<String, String> {
@@ -28,4 +64,34 @@ private object CapitalizeRequestHandler : RequestHandler<String, String> {
         input: String,
         context: Context,
     ): String = input.uppercase()
+}
+
+private object InferredCapitalizeRequestHandler : RequestHandler<String, String> {
+    override fun handle(
+        input: String,
+        context: Context,
+    ): String = input.uppercase()
+}
+
+private object MeasureEachRequestHandler : RequestHandler<List<String>, Map<String, Int>> {
+    override fun handle(
+        input: List<String>,
+        context: Context,
+    ): Map<String, Int> = input.associateWith { it.length }
+}
+
+private abstract class MeasuringRequestHandler<I : Any> : RequestHandler<I, Int>
+
+private object CountCharactersRequestHandler : MeasuringRequestHandler<String>() {
+    override fun handle(
+        input: String,
+        context: Context,
+    ): Int = input.length
+}
+
+private class EchoRequestHandler<T : Any> : RequestHandler<T, T> {
+    override fun handle(
+        input: T,
+        context: Context,
+    ): T = input
 }

--- a/coroutines/build.gradle.kts
+++ b/coroutines/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    alias(libs.plugins.kotlin.serialization)
+}
+
 dependencies {
     api(project(":core"))
     api(libs.kotlinx.coroutines.core)

--- a/coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestHandler.kt
+++ b/coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestHandler.kt
@@ -2,6 +2,7 @@ package io.skrastrek.aws.lambda.kotlin.coroutines
 
 import com.amazonaws.services.lambda.runtime.Context
 import io.skrastrek.aws.lambda.kotlin.core.EmptyContext
+import io.skrastrek.aws.lambda.kotlin.core.SerializerInference
 import io.skrastrek.aws.lambda.kotlin.core.json
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
@@ -10,6 +11,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
+import kotlinx.serialization.serializer
 import java.io.InputStream
 import java.io.OutputStream
 
@@ -23,8 +25,24 @@ import java.io.OutputStream
  * caller uses, while [handle] itself runs on the caller's context.
  */
 interface SuspendingRequestHandler<I : Any, O : Any> : SuspendingRequestStreamHandler {
+    /**
+     * Reads [I] off the wire. Defaults to the serializer for whatever [I] is bound to by the
+     * implementing class, so `SuspendingRequestHandler<Foo, Bar>` needs no declaration here.
+     * Override to use a different strategy, or when the binding is not concrete — see
+     * [SerializerInference].
+     */
+    @Suppress("UNCHECKED_CAST")
     val deserializer: DeserializationStrategy<I>
+        get() =
+            SerializerInference
+                .serializersOf(this, SuspendingRequestHandler::class.java)[0] as DeserializationStrategy<I>
+
+    /** Writes [O] to the wire. Inferred like [deserializer]. */
+    @Suppress("UNCHECKED_CAST")
     val serializer: SerializationStrategy<O>
+        get() =
+            SerializerInference
+                .serializersOf(this, SuspendingRequestHandler::class.java)[1] as SerializationStrategy<O>
 
     suspend fun handle(
         input: I,
@@ -47,6 +65,27 @@ interface SuspendingRequestHandler<I : Any, O : Any> : SuspendingRequestStreamHa
     @OptIn(ExperimentalSerializationApi::class)
     private fun O.jsonEncodeTo(output: OutputStream) = json.encodeToStream(serializer, this, output)
 }
+
+/**
+ * A [SuspendingRequestHandler] built from [handle].
+ *
+ * The serializers come from the reified type arguments, which the serialization plugin resolves at
+ * the call site — no reflection, unlike the inferred defaults on the interface. Use this for
+ * handlers the custom runtime constructs itself; the AWS managed runtime resolves handlers by class
+ * name and needs a named class implementing [SuspendingRequestHandler] instead.
+ */
+inline fun <reified I : Any, reified O : Any> SuspendingRequestHandler(
+    crossinline handle: suspend (input: I, context: Context) -> O,
+): SuspendingRequestHandler<I, O> =
+    object : SuspendingRequestHandler<I, O> {
+        override val deserializer = serializer<I>()
+        override val serializer = serializer<O>()
+
+        override suspend fun handle(
+            input: I,
+            context: Context,
+        ): O = handle(input, context)
+    }
 
 suspend fun <I : Any, O : Any> SuspendingRequestHandler<I, O>.handle(input: I): O = handle(input, EmptyContext)
 

--- a/coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestHandler.kt
+++ b/coroutines/src/main/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestHandler.kt
@@ -3,12 +3,12 @@ package io.skrastrek.aws.lambda.kotlin.coroutines
 import com.amazonaws.services.lambda.runtime.Context
 import io.skrastrek.aws.lambda.kotlin.core.EmptyContext
 import io.skrastrek.aws.lambda.kotlin.core.SerializerInference
-import io.skrastrek.aws.lambda.kotlin.core.json
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
 import kotlinx.serialization.serializer
@@ -26,6 +26,13 @@ import java.io.OutputStream
  */
 interface SuspendingRequestHandler<I : Any, O : Any> : SuspendingRequestStreamHandler {
     /**
+     * The [Json] used on the wire. Override to change its configuration, or to register contextual
+     * serializers — which is also how to keep serializer lookup reflection-free, see
+     * [SerializerInference].
+     */
+    val json: Json get() = io.skrastrek.aws.lambda.kotlin.core.json
+
+    /**
      * Reads [I] off the wire. Defaults to the serializer for whatever [I] is bound to by the
      * implementing class, so `SuspendingRequestHandler<Foo, Bar>` needs no declaration here.
      * Override to use a different strategy, or when the binding is not concrete — see
@@ -33,16 +40,15 @@ interface SuspendingRequestHandler<I : Any, O : Any> : SuspendingRequestStreamHa
      */
     @Suppress("UNCHECKED_CAST")
     val deserializer: DeserializationStrategy<I>
-        get() =
-            SerializerInference
-                .serializersOf(this, SuspendingRequestHandler::class.java)[0] as DeserializationStrategy<I>
+        get() = inferredSerializers()[0] as DeserializationStrategy<I>
 
     /** Writes [O] to the wire. Inferred like [deserializer]. */
     @Suppress("UNCHECKED_CAST")
     val serializer: SerializationStrategy<O>
-        get() =
-            SerializerInference
-                .serializersOf(this, SuspendingRequestHandler::class.java)[1] as SerializationStrategy<O>
+        get() = inferredSerializers()[1] as SerializationStrategy<O>
+
+    private fun inferredSerializers() =
+        SerializerInference.serializersOf(javaClass, SuspendingRequestHandler::class.java, json.serializersModule)
 
     suspend fun handle(
         input: I,

--- a/coroutines/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestHandlerTest.kt
+++ b/coroutines/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/coroutines/SuspendingRequestHandlerTest.kt
@@ -39,6 +39,29 @@ class SuspendingRequestHandlerTest {
     }
 
     @Test
+    fun `serializers are inferred from the type arguments`() =
+        runTest {
+            val input = ByteArrayInputStream(json.encodeToString("hello world").toByteArray())
+            val output = ByteArrayOutputStream()
+
+            InferredCapitalizeRequestHandler.handle(input, output)
+
+            assertEquals(json.encodeToString("HELLO WORLD"), output.toString(Charsets.UTF_8))
+        }
+
+    @Test
+    fun `factory builds a handler from a lambda`() =
+        runTest {
+            val handler = SuspendingRequestHandler<String, Int> { input, _ -> input.length }
+            val input = ByteArrayInputStream(json.encodeToString("hello world").toByteArray())
+            val output = ByteArrayOutputStream()
+
+            handler.handle(input, output)
+
+            assertEquals(json.encodeToString(11), output.toString(Charsets.UTF_8))
+        }
+
+    @Test
     fun `asSuspending returns a suspending handler unchanged`() {
         assertSame(CapitalizeRequestHandler, CapitalizeRequestHandler.asSuspending())
     }
@@ -56,6 +79,16 @@ class SuspendingRequestHandlerTest {
 
             assertEquals("payload", output.toString(Charsets.UTF_8))
         }
+}
+
+private object InferredCapitalizeRequestHandler : SuspendingRequestHandler<String, String> {
+    override suspend fun handle(
+        input: String,
+        context: Context,
+    ): String {
+        delay(1)
+        return input.uppercase()
+    }
 }
 
 private object CapitalizeRequestHandler : SuspendingRequestHandler<String, String> {

--- a/events/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/events/InferredSerializersTest.kt
+++ b/events/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/events/InferredSerializersTest.kt
@@ -1,0 +1,41 @@
+package io.skrastrek.aws.lambda.kotlin.events
+
+import com.amazonaws.services.lambda.runtime.Context
+import io.skrastrek.aws.lambda.kotlin.core.RequestHandler
+import io.skrastrek.aws.lambda.kotlin.core.handle
+import io.skrastrek.aws.lambda.kotlin.core.json
+import kotlinx.serialization.encodeToString
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import kotlin.test.assertEquals
+
+/**
+ * A handler for a library event type, written without the per-event interfaces and without naming
+ * either serializer — the crux of what inference has to support.
+ */
+class InferredSerializersTest {
+    @Test
+    fun handles_an_sqs_event_without_declared_serializers() {
+        val input = Utils::class.java.classLoader.getResourceAsStream("sqs-event-1.json")!!
+        val output = ByteArrayOutputStream()
+
+        FailEverySqsRecord.handle(input, output)
+
+        val expected =
+            BatchEventResponse(
+                json
+                    .decodeFromResource<SqsEvent>("sqs-event-1.json")
+                    .records
+                    .map { BatchItemFailure(it.messageId) },
+            )
+
+        assertEquals(json.encodeToString(expected), output.toString(Charsets.UTF_8))
+    }
+}
+
+private object FailEverySqsRecord : RequestHandler<SqsEvent, BatchEventResponse> {
+    override fun handle(
+        input: SqsEvent,
+        context: Context,
+    ): BatchEventResponse = BatchEventResponse(input.records.map { BatchItemFailure(it.messageId) })
+}

--- a/events/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/events/InferredSerializersTest.kt
+++ b/events/src/test/kotlin/io/skrastrek/aws/lambda/kotlin/events/InferredSerializersTest.kt
@@ -5,6 +5,9 @@ import io.skrastrek.aws.lambda.kotlin.core.RequestHandler
 import io.skrastrek.aws.lambda.kotlin.core.handle
 import io.skrastrek.aws.lambda.kotlin.core.json
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
 import kotlin.test.assertEquals
@@ -15,25 +18,53 @@ import kotlin.test.assertEquals
  */
 class InferredSerializersTest {
     @Test
+    fun handles_an_sqs_event_with_contextual_serializers() {
+        val output = ByteArrayOutputStream()
+
+        ContextualSqsHandler.handle(Utils::class.java.classLoader.getResourceAsStream("sqs-event-1.json")!!, output)
+
+        assertEquals(expectedFailures(), output.toString(Charsets.UTF_8))
+    }
+
+    @Test
     fun handles_an_sqs_event_without_declared_serializers() {
         val input = Utils::class.java.classLoader.getResourceAsStream("sqs-event-1.json")!!
         val output = ByteArrayOutputStream()
 
         FailEverySqsRecord.handle(input, output)
 
-        val expected =
-            BatchEventResponse(
-                json
-                    .decodeFromResource<SqsEvent>("sqs-event-1.json")
-                    .records
-                    .map { BatchItemFailure(it.messageId) },
-            )
-
-        assertEquals(json.encodeToString(expected), output.toString(Charsets.UTF_8))
+        assertEquals(expectedFailures(), output.toString(Charsets.UTF_8))
     }
 }
 
+private fun expectedFailures(): String =
+    json.encodeToString(
+        BatchEventResponse(
+            json.decodeFromResource<SqsEvent>("sqs-event-1.json").records.map { BatchItemFailure(it.messageId) },
+        ),
+    )
+
 private object FailEverySqsRecord : RequestHandler<SqsEvent, BatchEventResponse> {
+    override fun handle(
+        input: SqsEvent,
+        context: Context,
+    ): BatchEventResponse = BatchEventResponse(input.records.map { BatchItemFailure(it.messageId) })
+}
+
+/**
+ * Serializers registered contextually rather than looked up. This is the reflection-free route for
+ * handlers a GraalVM image build cannot see, so the wiring has to reach the inference.
+ */
+private object ContextualSqsHandler : RequestHandler<SqsEvent, BatchEventResponse> {
+    override val json =
+        Json(io.skrastrek.aws.lambda.kotlin.core.json) {
+            serializersModule =
+                SerializersModule {
+                    contextual(SqsEvent::class, SqsEvent.serializer())
+                    contextual(BatchEventResponse::class, BatchEventResponse.serializer())
+                }
+        }
+
     override fun handle(
         input: SqsEvent,
         context: Context,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,8 @@ maven-publish = "0.37.0"
 # Libs
 aws-lambda-java-core = "1.4.0"
 
+graalvm-sdk = "25.0.4"
+
 kotlinx-coroutines = "1.11.0"
 kotlinx-serialization = "1.11.0"
 
@@ -22,6 +24,8 @@ maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publ
 
 [libraries]
 aws-lambda-java-core = { group = "com.amazonaws", name = "aws-lambda-java-core", version.ref = "aws-lambda-java-core" }
+
+graalvm-nativeimage = { group = "org.graalvm.sdk", name = "nativeimage", version.ref = "graalvm-sdk" }
 
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }


### PR DESCRIPTION
Implementing `RequestHandler<I, O>` required restating both serializers, which is why every event type ships its own handler interface. A class that names its type arguments records them in its class-file generic signature, so they can be read back at runtime instead:

```kotlin
class MyHandler : RequestHandler<SqsEvent, BatchEventResponse> {
    override fun handle(input: SqsEvent, context: Context) = ...
}
```

Both serializer properties now default to that inference (`SerializerInference`), cached per handler class so the reflection happens once and later invocations are a map lookup. Explicit overrides still win, so this is fully backward compatible — nothing in `events` changed, and the `SqsEventRequestHandler`-style interfaces still work; they just become optional.

Where the handler is constructed rather than named — the custom runtime path — new reified factories take the serializers from type parameters, which the serialization plugin resolves at the call site with no reflection at all:

```kotlin
val handler = RequestHandler<Foo, Bar> { input, context -> ... }   // and SuspendingRequestHandler { }
```

### Verified

- `@Serializable` data classes end to end (`SqsEvent` → `BatchEventResponse` over a real fixture), built-ins, inheritance through an intermediate abstract class, and parameterized arguments where Kotlin's variance emits `List<? extends String>`.
- No `kotlin-reflect` needed — confirmed absent from the `events` test runtime classpath.
- Clean `./gradlew build --rerun-tasks`: all tests pass, ktlint clean.

### Trade-offs

- A handler that leaves the argument generic (`class Handler<T> : RequestHandler<T, Unit>`) is erased and cannot be inferred. It fails with a message naming the type variable and the two ways out.
- Inference fails at first invocation rather than at compile time — that guarantee is what's traded for the terser interface. The factories keep it where it matters.
- GraalVM native-image would need reflection metadata for the inferred path; the factories or an explicit override sidestep it entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)